### PR TITLE
chore: add CODEOWNERS + clang-tidy config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,38 @@
+# ===========================================================================
+# Clang-Tidy configuration for UltrafastSecp256k1
+# ===========================================================================
+# Run: clang-tidy -p build cpu/src/*.cpp -- -std=c++20
+# ===========================================================================
+
+Checks: >
+  -*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions,
+  cert-*,
+  -cert-err58-cpp,
+  clang-analyzer-*,
+  cppcoreguidelines-init-variables,
+  cppcoreguidelines-pro-type-cstyle-cast,
+  misc-const-correctness,
+  misc-redundant-expression,
+  misc-unused-using-decls,
+  modernize-use-auto,
+  modernize-use-nullptr,
+  modernize-use-override,
+  performance-*,
+  -performance-no-int-to-ptr,
+  readability-braces-around-statements,
+  readability-const-return-type,
+  readability-redundant-string-cstr,
+  readability-simplify-boolean-expr
+
+WarningsAsErrors: ''
+
+HeaderFilterRegex: '(cpu|include)/.*\.(hpp|h)$'
+
+CheckOptions:
+  - key:   readability-braces-around-statements.ShortStatementLines
+    value: '1'
+  - key:   cppcoreguidelines-init-variables.IncludeStyle
+    value: 'llvm'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# CODEOWNERS — defines code review ownership
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# These owners are automatically requested for review on pull requests
+# that modify the matched files.
+
+# Default owner for everything
+* @shrec
+
+# Core cryptographic code — requires careful review
+/cpu/src/        @shrec
+/cpu/include/    @shrec
+
+# GPU backends
+/cuda/           @shrec
+/opencl/         @shrec
+/metal/          @shrec
+
+# Security-sensitive files
+/SECURITY.md     @shrec
+/THREAT_MODEL.md @shrec
+
+# CI/CD workflows
+/.github/        @shrec
+
+# Packaging
+/packaging/      @shrec
+
+# Bindings (C ABI, Java, Python, etc.)
+/bindings/       @shrec
+/include/ufsecp/ @shrec


### PR DESCRIPTION
## Changes

- **\.github/CODEOWNERS\** — auto-assigns @shrec for review on all PRs (crypto core, GPU backends, CI, bindings, packaging)
- **\.clang-tidy\** — static analysis configuration: bugprone, cert, performance, readability, clang-analyzer checks

## Why

- CODEOWNERS ensures every PR gets a reviewer assigned automatically
- clang-tidy enables local + CI static analysis beyond what CodeQL covers
- Both improve OpenSSF Scorecard Code-Review and SAST scores