### PR TITLE
docs: add Linux package install instructions + Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# ===========================================================================
+# UltrafastSecp256k1 — Reproducible build + test container
+# ===========================================================================
+# Build:  docker build -t ultrafastsecp256k1 .
+# Test:   docker run --rm ultrafastsecp256k1
+# Bench:  docker run --rm ultrafastsecp256k1 ./build/cpu/bench_comprehensive
+# ===========================================================================
+
+FROM ubuntu:24.04 AS builder
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        cmake ninja-build g++ ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+RUN cmake -S . -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DSECP256K1_BUILD_TESTS=ON \
+        -DSECP256K1_BUILD_BENCH=ON \
+        -DSECP256K1_BUILD_SHARED=ON \
+        -DSECP256K1_INSTALL=ON \
+        -DSECP256K1_USE_ASM=ON && \
+    cmake --build build -j"$(nproc)"
+
+# Run tests as build verification
+RUN ctest --test-dir build --output-on-failure
+
+# --------------------------------------------------------------------------
+# Runtime image (minimal)
+# --------------------------------------------------------------------------
+FROM ubuntu:24.04 AS runtime
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends libstdc++6 && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /src/build/cpu/libfastsecp256k1.so* /usr/lib/
+COPY --from=builder /src/build/cpu/bench_comprehensive /usr/bin/
+COPY --from=builder /src/cpu/include/secp256k1 /usr/include/secp256k1/
+
+RUN ldconfig
+
+ENTRYPOINT ["bench_comprehensive"]

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -617,7 +617,49 @@ ctest --test-dir build --output-on-failure
 
 ---
 
+## Install from Linux Packages
+
+Pre-built packages are available for each [GitHub Release](https://github.com/shrec/UltrafastSecp256k1/releases).
+
+### Debian / Ubuntu (APT)
+
+```bash
+# Add the repository
+curl -fsSL https://shrec.github.io/UltrafastSecp256k1/apt/KEY.gpg \
+  | sudo gpg --dearmor -o /etc/apt/keyrings/ultrafastsecp256k1.gpg
+echo "deb [signed-by=/etc/apt/keyrings/ultrafastsecp256k1.gpg] \
+  https://shrec.github.io/UltrafastSecp256k1/apt stable main" \
+  | sudo tee /etc/apt/sources.list.d/ultrafastsecp256k1.list
+
+sudo apt update
+sudo apt install libsecp256k1-fast-dev   # headers + static + shared
+```
+
+### Fedora / RHEL (RPM)
+
+```bash
+# Download the latest .rpm from GitHub Releases
+curl -LO "https://github.com/shrec/UltrafastSecp256k1/releases/latest/download/\
+UltrafastSecp256k1-$(rpm -E %{_arch}).rpm"
+sudo dnf install ./UltrafastSecp256k1-*.rpm
+```
+
+### Arch Linux (AUR)
+
+```bash
+yay -S libsecp256k1-fast
+```
+
+### Docker (build from source)
+
+```bash
+docker build -t ultrafastsecp256k1 -f Dockerfile .
+docker run --rm ultrafastsecp256k1 ctest --output-on-failure
+```
+
+---
+
 ## Version
 
-UltrafastSecp256k1 v3.0.0
+Current version is read from `VERSION.txt` at configure time.
 


### PR DESCRIPTION
## Changes
- Add Linux distribution package installation instructions to BUILDING.md (APT, RPM, Arch/AUR)
- Add Docker build section with usage examples
- Update version reference to use VERSION.txt
- Add multi-stage Dockerfile (builder + minimal runtime image)

## Why
Improves onboarding for Linux users who prefer package managers or containers over building from source.
Complements the packaging infrastructure added in previous commits.