### PR TITLE
chore: update SECURITY.md version table + add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Description
+
+<!-- Brief summary of changes -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Performance improvement
+- [ ] Breaking change (fix or feature that causes existing functionality to change)
+- [ ] Documentation update
+- [ ] CI/Build infrastructure
+
+## Changes Made
+
+<!-- List key changes -->
+
+-
+
+## Testing
+
+- [ ] All existing tests pass (`ctest --test-dir build --output-on-failure`)
+- [ ] New tests added (if applicable)
+- [ ] Benchmark results attached (if performance-related)
+
+## Hot Path Checklist (if applicable)
+
+- [ ] Zero heap allocations in hot path
+- [ ] No strings/iostreams/exceptions in hot path
+- [ ] Explicit in/out/scratch buffers
+- [ ] No `%` or `/` where Montgomery/Barrett is available
+
+## Additional Notes
+
+<!-- Any other context about the PR -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,10 @@
 
 | Version | Supported |
 |---------|-----------|
-| 3.11.x  | ✅ Active  |
+| 3.12.x  | ✅ Active  |
+| 3.11.x  | ⚠️ Critical fixes only |
 | 3.9.x–3.10.x | ⚠️ Critical fixes only |
-| 3.6.x–3.8.x | ⚠️ Critical fixes only |
-| < 3.6   | ❌ Unsupported |
+| < 3.9   | ❌ Unsupported |
 
 Security fixes apply to the latest release on the `main` branch.
 


### PR DESCRIPTION
## Changes
- Update SECURITY.md supported versions table: 3.12.x is now Active, 3.11.x → critical fixes only, <3.9 unsupported
- Add .github/PULL_REQUEST_TEMPLATE.md with standard checklist (type of change, testing, hot path audit)

## Why
Keeps security policy current with v3.12.1 release. PR template enforces quality checklist for all contributors.