### PR TITLE
ci: pin pip deps by hash + fix cosign signing visibility

### DIFF
--- a/.github/requirements/cppcheck.txt
+++ b/.github/requirements/cppcheck.txt
@@ -1,0 +1,4 @@
+# Pinned dependency for cppcheck workflow (hash-verified)
+# Regenerate: pip download 'cppcheck-codequality==1.4.2' && pip hash <file>
+cppcheck-codequality==1.4.2 \
+    --hash=sha256:5b73e80efe173eb8b9deb8f3d60461eddd92540e19cf6f15d4aa96e7e3d3f319

--- a/.github/requirements/mutation.txt
+++ b/.github/requirements/mutation.txt
@@ -1,0 +1,4 @@
+# Pinned dependency for mutation workflow (hash-verified)
+# Regenerate: pip download 'mutmut==3.5.0' && pip hash <file>
+mutmut==3.5.0 \
+    --hash=sha256:f19f2dd2e977eb9dc17255d8cb11e24fbfc3191620fba3108cac25779c9d78c9

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends cppcheck ninja-build python3-pip
-          pip3 install --user 'cppcheck-codequality==1.4.0' 2>/dev/null || true
+          pip3 install --require-hashes --no-deps -r .github/requirements/cppcheck.txt 2>/dev/null || true
 
       - name: Configure (generate compile_commands.json)
         run: |

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -46,7 +46,7 @@ jobs:
             -O /tmp/mull.deb 2>/dev/null || {
             # Fallback: try building a minimal mutation runner
             echo "::warning::Mull .deb not available, trying pip package"
-            pip3 install --user 'mutmut==2.4.4' 2>/dev/null || true
+            pip3 install --require-hashes --no-deps -r .github/requirements/mutation.txt 2>/dev/null || true
           }
           if [ -f /tmp/mull.deb ]; then
             sudo dpkg -i /tmp/mull.deb 2>/dev/null || sudo apt-get install -f -y

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1586,24 +1586,39 @@ jobs:
 
       - name: Sign release artifacts with cosign
         run: |
+          echo "cosign version: $(cosign version 2>&1 | head -1)"
+
           # Sign the SHA256SUMS manifest itself (most important)
           echo "Signing: SHA256SUMS"
-          cosign sign-blob --yes SHA256SUMS \
-            --output-signature SHA256SUMS.sig \
-            --output-certificate SHA256SUMS.pem 2>/dev/null || \
-            echo "  (skipped -- cosign keyless requires OIDC)"
+          if cosign sign-blob --yes SHA256SUMS \
+               --output-signature SHA256SUMS.sig \
+               --output-certificate SHA256SUMS.pem; then
+            echo "  [OK] SHA256SUMS signed"
+          else
+            echo "::warning::cosign sign-blob failed for SHA256SUMS (exit $?)"
+          fi
 
           # Sign individual release archives
+          SIGNED=0
+          FAILED=0
           cd dist
           find . -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.whl' \
             -o -name '*.nupkg' -o -name '*.tgz' -o -name '*.gem' -o -name '*.jar' \) \
             | while read -r f; do
               echo "Signing: $f"
-              cosign sign-blob --yes "$f" --output-signature "${f}.sig" \
-                --output-certificate "${f}.pem" 2>/dev/null || \
-              echo "  (skipped -- cosign keyless requires OIDC)"
+              if cosign sign-blob --yes "$f" \
+                   --output-signature "${f}.sig" \
+                   --output-certificate "${f}.pem"; then
+                SIGNED=$((SIGNED+1))
+              else
+                echo "::warning::cosign sign-blob failed for $f (exit $?)"
+                FAILED=$((FAILED+1))
+              fi
             done
           cd ..
+
+          echo "=== Cosign summary: signed=${SIGNED:-0} failed=${FAILED:-0} ==="
+          ls -la SHA256SUMS.sig SHA256SUMS.pem 2>/dev/null || echo "No SHA256SUMS signature files found"
 
       # -- Verification Artifacts --
       - name: Generate verification artifacts


### PR DESCRIPTION
## Scorecard Pinned-Dependencies (9 -> 10)

- Create \.github/requirements/cppcheck.txt\ with hash-pinned \cppcheck-codequality==1.4.2\
- Create \.github/requirements/mutation.txt\ with hash-pinned \mutmut==3.5.0\
- Update \cppcheck.yml\: use \--require-hashes --no-deps -r\ requirements file
- Update \mutation.yml\: use \--require-hashes --no-deps -r\ requirements file

All 4 pip commands in CI now use hash-pinned requirements files (following existing pattern in \indings.yml\ and \elease.yml\).

## Scorecard Signed-Releases (diagnostic fix)

- Remove \2>/dev/null\ from cosign \sign-blob\ commands in \elease.yml\
- Print cosign version at start of signing step
- Replace silent \|| echo (skipped)\ fallback with \::warning\ annotations
- Add summary listing of generated \.sig\/\.pem\ files
- Next release tag will expose the actual cosign failure reason in CI logs

## Verify

- Scorecard rescan should show 4/4 pip deps hash-pinned (Pinned-Dependencies 10/10)
- Next release will reveal why cosign keyless signing was silently failing