### PR TITLE
fix: last duplicate const in test_frost_kat.cpp (GCC-13 error)

### DIFF
--- a/audit/test_frost_kat.cpp
+++ b/audit/test_frost_kat.cpp
@@ -291,7 +291,7 @@ static void test_2of3_full_signing() {
     for (int i = 0; i < 32; ++i) msg[i] = static_cast<uint8_t>(0xCA + i);
 
     // Try ALL 3 signer subsets: {1,2}, {1,3}, {2,3}
-    const secp256k1::FrostKeyPackage const* all_kps[] = {&kp1, &kp2, &kp3};
+    const secp256k1::FrostKeyPackage* const all_kps[] = {&kp1, &kp2, &kp3};
     uint32_t const subset_ids[][2] = {{1, 2}, {1, 3}, {2, 3}};
 
     for (int s = 0; s < 3; ++s) {


### PR DESCRIPTION
## Problem
\const secp256k1::FrostKeyPackage const*\ is rejected by GCC-13 as duplicate \const\ qualifier (same class of bug fixed in PR #54, but this instance was missed because the grep pattern only matched \const char const*\).

## Fix
\const secp256k1::FrostKeyPackage const*\ -> \const secp256k1::FrostKeyPackage* const\

## Verification
- Local build: 48/48 targets OK (MSVC)
- Local tests: 25/25 passed
- No other duplicate const patterns remain in source (verified via regex search)