### PR TITLE
fix: suppress ~550 code scanning alerts (batch 2)

### DIFF
--- a/audit/audit_ct.cpp
+++ b/audit/audit_ct.cpp
@@ -36,13 +36,13 @@ static const char* g_section = "";
     } \
 } while(0)
 
-static std::mt19937_64 rng(0xA0D17'C7C7A);
+static std::mt19937_64 rng(0xA0D17'C7C7A);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
 
 static Scalar random_scalar() {
     std::array<uint8_t, 32> out{};
     for (int i = 0; i < 4; ++i) {
         uint64_t v = rng();
-        std::memcpy(out.data() + i * 8, &v, 8);
+        std::memcpy(out.data() + static_cast<std::size_t>(i) * 8, &v, 8);
     }
     for (;;) {
         auto s = Scalar::from_bytes(out);
@@ -55,7 +55,7 @@ static FieldElement random_fe() {
     std::array<uint8_t, 32> out{};
     for (int i = 0; i < 4; ++i) {
         uint64_t v = rng();
-        std::memcpy(out.data() + i * 8, &v, 8);
+        std::memcpy(out.data() + static_cast<std::size_t>(i) * 8, &v, 8);
     }
     return FieldElement::from_bytes(out);
 }

--- a/audit/audit_field.cpp
+++ b/audit/audit_field.cpp
@@ -21,22 +21,22 @@ static int g_pass = 0, g_fail = 0;
 static const char* g_section = "";
 
 #define CHECK(cond, msg) do { \
-    if (!(cond)) { \
+    if (cond) { \
+        ++g_pass; \
+    } else { \
         printf("  FAIL [%s]: %s (line %d)\n", g_section, msg, __LINE__); \
         ++g_fail; \
-    } else { \
-        ++g_pass; \
     } \
 } while(0)
 
 // Deterministic PRNG
-static std::mt19937_64 rng(0xA0D17'F1E1D);
+static std::mt19937_64 rng(0xA0D17'F1E1D);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
 
 static std::array<uint8_t, 32> random_bytes() {
     std::array<uint8_t, 32> out{};
     for (int i = 0; i < 4; ++i) {
         uint64_t v = rng();
-        std::memcpy(out.data() + i * 8, &v, 8);
+        std::memcpy(out.data() + static_cast<std::size_t>(i) * 8, &v, 8);
     }
     return out;
 }
@@ -279,7 +279,7 @@ static void test_canonical() {
             if (bytes[j] < P_BYTES[j]) { less = true; break; }
             if (bytes[j] > P_BYTES[j]) { greater = true; break; }
         }
-        CHECK(less || (!less && !greater), "serialized value < p or == 0");
+        CHECK(!greater, "serialized value < p or == 0");
         CHECK(!greater, "no value exceeds p");
     }
 

--- a/audit/audit_fuzz.cpp
+++ b/audit/audit_fuzz.cpp
@@ -27,21 +27,21 @@ static int g_pass = 0, g_fail = 0;
 static const char* g_section = "";
 
 #define CHECK(cond, msg) do { \
-    if (!(cond)) { \
+    if (cond) { \
+        ++g_pass; \
+    } else { \
         printf("  FAIL [%s]: %s (line %d)\n", g_section, msg, __LINE__); \
         ++g_fail; \
-    } else { \
-        ++g_pass; \
     } \
 } while(0)
 
-static std::mt19937_64 rng(0xA0D17'F0220);
+static std::mt19937_64 rng(0xA0D17'F0220);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
 
 static Scalar random_scalar() {
     std::array<uint8_t, 32> out{};
     for (int i = 0; i < 4; ++i) {
         uint64_t v = rng();
-        std::memcpy(out.data() + i * 8, &v, 8);
+        std::memcpy(out.data() + static_cast<std::size_t>(i) * 8, &v, 8);
     }
     for (;;) {
         auto s = Scalar::from_bytes(out);

--- a/audit/audit_integration.cpp
+++ b/audit/audit_integration.cpp
@@ -29,21 +29,21 @@ static int g_pass = 0, g_fail = 0;
 static const char* g_section = "";
 
 #define CHECK(cond, msg) do { \
-    if (!(cond)) { \
+    if (cond) { \
+        ++g_pass; \
+    } else { \
         printf("  FAIL [%s]: %s (line %d)\n", g_section, msg, __LINE__); \
         ++g_fail; \
-    } else { \
-        ++g_pass; \
     } \
 } while(0)
 
-static std::mt19937_64 rng(0xA0D17'1D7E6);
+static std::mt19937_64 rng(0xA0D17'1D7E6);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
 
 static Scalar random_scalar() {
     std::array<uint8_t, 32> out{};
     for (int i = 0; i < 4; ++i) {
         uint64_t v = rng();
-        std::memcpy(out.data() + i * 8, &v, 8);
+        std::memcpy(out.data() + static_cast<std::size_t>(i) * 8, &v, 8);
     }
     for (;;) {
         auto s = Scalar::from_bytes(out);

--- a/audit/audit_perf.cpp
+++ b/audit/audit_perf.cpp
@@ -21,13 +21,13 @@
 
 using namespace secp256k1::fast;
 
-static std::mt19937_64 rng(0xA0D17'BEFFA);
+static std::mt19937_64 rng(0xA0D17'BEFFA);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
 
 static Scalar random_scalar() {
     std::array<uint8_t, 32> out{};
     for (int i = 0; i < 4; ++i) {
         uint64_t v = rng();
-        std::memcpy(out.data() + i * 8, &v, 8);
+        std::memcpy(out.data() + static_cast<std::size_t>(i) * 8, &v, 8);
     }
     for (;;) {
         auto s = Scalar::from_bytes(out);
@@ -40,7 +40,7 @@ static FieldElement random_fe() {
     std::array<uint8_t, 32> out{};
     for (int i = 0; i < 4; ++i) {
         uint64_t v = rng();
-        std::memcpy(out.data() + i * 8, &v, 8);
+        std::memcpy(out.data() + static_cast<std::size_t>(i) * 8, &v, 8);
     }
     return FieldElement::from_bytes(out);
 }

--- a/audit/audit_point.cpp
+++ b/audit/audit_point.cpp
@@ -25,21 +25,21 @@ static int g_pass = 0, g_fail = 0;
 static const char* g_section = "";
 
 #define CHECK(cond, msg) do { \
-    if (!(cond)) { \
+    if (cond) { \
+        ++g_pass; \
+    } else { \
         printf("  FAIL [%s]: %s (line %d)\n", g_section, msg, __LINE__); \
         ++g_fail; \
-    } else { \
-        ++g_pass; \
     } \
 } while(0)
 
-static std::mt19937_64 rng(0xA0D17'F01DA);
+static std::mt19937_64 rng(0xA0D17'F01DA);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
 
 static Scalar random_scalar() {
     std::array<uint8_t, 32> out{};
     for (int i = 0; i < 4; ++i) {
         uint64_t v = rng();
-        std::memcpy(out.data() + i * 8, &v, 8);
+        std::memcpy(out.data() + static_cast<std::size_t>(i) * 8, &v, 8);
     }
     for (;;) {
         auto s = Scalar::from_bytes(out);

--- a/audit/audit_scalar.cpp
+++ b/audit/audit_scalar.cpp
@@ -20,21 +20,21 @@ static int g_pass = 0, g_fail = 0;
 static const char* g_section = "";
 
 #define CHECK(cond, msg) do { \
-    if (!(cond)) { \
+    if (cond) { \
+        ++g_pass; \
+    } else { \
         printf("  FAIL [%s]: %s (line %d)\n", g_section, msg, __LINE__); \
         ++g_fail; \
-    } else { \
-        ++g_pass; \
     } \
 } while(0)
 
-static std::mt19937_64 rng(0xA0D17'5CA1A);
+static std::mt19937_64 rng(0xA0D17'5CA1A);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
 
 static std::array<uint8_t, 32> random_bytes() {
     std::array<uint8_t, 32> out{};
     for (int i = 0; i < 4; ++i) {
         uint64_t v = rng();
-        std::memcpy(out.data() + i * 8, &v, 8);
+        std::memcpy(out.data() + static_cast<std::size_t>(i) * 8, &v, 8);
     }
     return out;
 }

--- a/audit/audit_security.cpp
+++ b/audit/audit_security.cpp
@@ -28,21 +28,21 @@ static int g_pass = 0, g_fail = 0;
 static const char* g_section = "";
 
 #define CHECK(cond, msg) do { \
-    if (!(cond)) { \
+    if (cond) { \
+        ++g_pass; \
+    } else { \
         printf("  FAIL [%s]: %s (line %d)\n", g_section, msg, __LINE__); \
         ++g_fail; \
-    } else { \
-        ++g_pass; \
     } \
 } while(0)
 
-static std::mt19937_64 rng(0xA0D17'5EC0A);
+static std::mt19937_64 rng(0xA0D17'5EC0A);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
 
 static Scalar random_scalar() {
     std::array<uint8_t, 32> out{};
     for (int i = 0; i < 4; ++i) {
         uint64_t v = rng();
-        std::memcpy(out.data() + i * 8, &v, 8);
+        std::memcpy(out.data() + static_cast<std::size_t>(i) * 8, &v, 8);
     }
     for (;;) {
         auto s = Scalar::from_bytes(out);
@@ -287,7 +287,7 @@ static void test_serialization_integrity() {
         std::array<uint8_t, 32> bytes{};
         for (int j = 0; j < 4; ++j) {
             uint64_t v = rng();
-            std::memcpy(bytes.data() + j * 8, &v, 8);
+            std::memcpy(bytes.data() + static_cast<std::size_t>(j) * 8, &v, 8);
         }
         // Ensure < p by clearing top bit
         bytes[0] &= 0x7F;

--- a/audit/differential_test.cpp
+++ b/audit/differential_test.cpp
@@ -33,16 +33,16 @@ using namespace secp256k1::fast;
 static int g_pass = 0, g_fail = 0;
 
 #define CHECK(cond, msg) do { \
-    if (!(cond)) { \
+    if (cond) { \
+        ++g_pass; \
+    } else { \
         printf("  FAIL: %s (line %d)\n", msg, __LINE__); \
         ++g_fail; \
-    } else { \
-        ++g_pass; \
     } \
 } while(0)
 
 // Deterministic PRNG for reproducibility (seed can be changed for different runs)
-static std::mt19937_64 rng(42);
+static std::mt19937_64 rng(42);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
 
 // Iteration multiplier: 1 = default (CI), larger = nightly/stress.
 // Set via argv[1] or DIFFERENTIAL_MULTIPLIER env var.
@@ -52,7 +52,7 @@ static std::array<uint8_t, 32> random_bytes() {
     std::array<uint8_t, 32> out{};
     for (int i = 0; i < 4; ++i) {
         uint64_t v = rng();
-        std::memcpy(out.data() + i * 8, &v, 8);
+        std::memcpy(out.data() + static_cast<std::size_t>(i) * 8, &v, 8);
     }
     return out;
 }

--- a/audit/test_abi_gate.cpp
+++ b/audit/test_abi_gate.cpp
@@ -47,9 +47,12 @@ int test_abi_gate_run() {
     CHECK(((packed >> 8) & 0xFF) == minor, "Packed minor matches");
     CHECK((packed & 0xFF) == patch, "Packed patch matches");
     const char* ver_str = UFSECP_VERSION_STRING;
+    // cppcheck-suppress nullPointerRedundantCheck
     CHECK(ver_str != nullptr, "Version string is non-null");
+    // cppcheck-suppress nullPointerRedundantCheck
     CHECK(strlen(ver_str) > 0, "Version string is non-empty");
     bool has_dot = false, has_digit = false;
+    // cppcheck-suppress nullPointerRedundantCheck
     for (const char* p = ver_str; *p; ++p) {
         if (*p == '.') has_dot = true;
         if (*p >= '0' && *p <= '9') has_digit = true;
@@ -94,13 +97,16 @@ int main() {
     // 5. Version string
     const char* ver_str = UFSECP_VERSION_STRING;
     printf("  UFSECP_VERSION_STRING:    \"%s\"\n", ver_str);
+    // cppcheck-suppress nullPointerRedundantCheck
     CHECK(ver_str != nullptr, "Version string is non-null");
+    // cppcheck-suppress nullPointerRedundantCheck
     CHECK(strlen(ver_str) > 0, "Version string is non-empty");
 
     // 6. Validate that version string contains digits and dots
     {
         bool has_dot = false;
         bool has_digit = false;
+        // cppcheck-suppress nullPointerRedundantCheck
         for (const char* p = ver_str; *p; ++p) {
             if (*p == '.') has_dot = true;
             if (*p >= '0' && *p <= '9') has_digit = true;

--- a/audit/test_carry_propagation.cpp
+++ b/audit/test_carry_propagation.cpp
@@ -26,11 +26,11 @@ static int g_pass = 0, g_fail = 0;
 static const char* g_section = "";
 
 #define CHECK(cond, msg) do { \
-    if (!(cond)) { \
-        printf("  FAIL [%s]: %s (line %d)\n", g_section, msg, __LINE__); \
-        ++g_fail; \
-    } else { \
+    if (cond) { \
         ++g_pass; \
+    } else { \
+        (void)printf("  FAIL [%s]: %s (line %d)\n", g_section, msg, __LINE__); \
+        ++g_fail; \
     } \
 } while(0)
 
@@ -47,8 +47,8 @@ static FieldElement fe_from_hex(const char* hex64) {
     std::array<uint8_t, 32> bytes{};
     for (int i = 0; i < 32; ++i) {
         unsigned hi = 0, lo = 0;
-        sscanf(hex64 + i * 2, "%1x", &hi);
-        sscanf(hex64 + i * 2 + 1, "%1x", &lo);
+        (void)sscanf(hex64 + static_cast<std::size_t>(i) * 2, "%1x", &hi);
+        (void)sscanf(hex64 + static_cast<std::size_t>(i) * 2 + 1, "%1x", &lo);
         bytes[i] = static_cast<uint8_t>((hi << 4) | lo);
     }
     return FieldElement::from_bytes(bytes);
@@ -65,7 +65,7 @@ static FieldElement fe_from_limbs4(uint64_t l0, uint64_t l1, uint64_t l2, uint64
 // ============================================================================
 static void test_all_ones() {
     g_section = "all_ones";
-    printf("[1] All-ones limb pattern (2^256 - 1)\n");
+    (void)printf("[1] All-ones limb pattern (2^256 - 1)\n");
 
     auto max_val = fe_from_limbs4(
         0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF,
@@ -101,7 +101,7 @@ static void test_all_ones() {
 // ============================================================================
 static void test_single_limb_max() {
     g_section = "single_limb_max";
-    printf("[2] Single-limb maximum patterns\n");
+    (void)printf("[2] Single-limb maximum patterns\n");
 
     auto one  = FieldElement::one();
     auto zero = FieldElement::zero();
@@ -137,7 +137,7 @@ static void test_single_limb_max() {
 // ============================================================================
 static void test_cross_limb_carry() {
     g_section = "cross_limb_carry";
-    printf("[3] Cross-limb boundary carry patterns\n");
+    (void)printf("[3] Cross-limb boundary carry patterns\n");
 
     auto one = FieldElement::one();
 
@@ -199,7 +199,7 @@ static void test_cross_limb_carry() {
 // ============================================================================
 static void test_near_prime() {
     g_section = "near_prime";
-    printf("[4] Values near the prime p (reduction boundary)\n");
+    (void)printf("[4] Values near the prime p (reduction boundary)\n");
 
     auto p_m1 = FieldElement::from_bytes(P_BYTES) - FieldElement::one();
     auto zero = FieldElement::zero();
@@ -243,7 +243,7 @@ static void test_near_prime() {
 // ============================================================================
 static void test_max_intermediate() {
     g_section = "max_intermediate";
-    printf("[5] Maximum intermediate values (carry chain stress)\n");
+    (void)printf("[5] Maximum intermediate values (carry chain stress)\n");
 
     auto one  = FieldElement::one();
 
@@ -282,7 +282,7 @@ static void test_max_intermediate() {
 // ============================================================================
 static void test_scalar_carry() {
     g_section = "scalar_carry";
-    printf("[6] Scalar carry propagation near group order n\n");
+    (void)printf("[6] Scalar carry propagation near group order n\n");
 
     // n = FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
     auto n_m1_bytes = std::array<uint8_t, 32>{
@@ -324,7 +324,7 @@ static void test_scalar_carry() {
 // ============================================================================
 static void test_point_carry() {
     g_section = "point_carry";
-    printf("[7] Point arithmetic carry propagation\n");
+    (void)printf("[7] Point arithmetic carry propagation\n");
 
     auto G = Point::generator();
 
@@ -382,7 +382,7 @@ int test_carry_propagation_run() {
     test_max_intermediate();
     test_scalar_carry();
     test_point_carry();
-    printf("  [carry_propagation] %d passed, %d failed\n", g_pass, g_fail);
+    (void)printf("  [carry_propagation] %d passed, %d failed\n", g_pass, g_fail);
     return g_fail > 0 ? 1 : 0;
 }
 
@@ -391,10 +391,10 @@ int test_carry_propagation_run() {
 // ============================================================================
 #ifndef UNIFIED_AUDIT_RUNNER
 int main() {
-    printf("============================================================\n");
-    printf("  Carry Propagation Stress Test\n");
-    printf("  Arithmetic boundary & limb carry-chain verification\n");
-    printf("============================================================\n\n");
+    (void)printf("============================================================\n");
+    (void)printf("  Carry Propagation Stress Test\n");
+    (void)printf("  Arithmetic boundary & limb carry-chain verification\n");
+    (void)printf("============================================================\n\n");
 
     test_all_ones();          printf("\n");
     test_single_limb_max();   printf("\n");
@@ -404,9 +404,9 @@ int main() {
     test_scalar_carry();      printf("\n");
     test_point_carry();
 
-    printf("\n============================================================\n");
-    printf("  Summary: %d passed, %d failed\n", g_pass, g_fail);
-    printf("============================================================\n");
+    (void)printf("\n============================================================\n");
+    (void)printf("  Summary: %d passed, %d failed\n", g_pass, g_fail);
+    (void)printf("============================================================\n");
 
     return g_fail > 0 ? 1 : 0;
 }

--- a/audit/test_cross_platform_kat.cpp
+++ b/audit/test_cross_platform_kat.cpp
@@ -39,7 +39,7 @@ static bool g_generate = false;
 
 #define CHECK(cond, msg) do { \
     if (!(cond)) { \
-        printf("  FAIL [%s]: %s (line %d)\n", g_section, msg, __LINE__); \
+        (void)printf("  FAIL [%s]: %s (line %d)\n", g_section, msg, __LINE__); \
         ++g_fail; \
     } else { \
         ++g_pass; \
@@ -51,7 +51,7 @@ static std::string bytes_to_hex(const uint8_t* data, size_t len) {
     out.reserve(len * 2);
     for (size_t i = 0; i < len; ++i) {
         char buf[3];
-        snprintf(buf, sizeof(buf), "%02x", data[i]);
+        (void)snprintf(buf, sizeof(buf), "%02x", data[i]);
         out += buf;
     }
     return out;
@@ -60,11 +60,11 @@ static std::string bytes_to_hex(const uint8_t* data, size_t len) {
 static void verify_hex(const char* label, const uint8_t* data, size_t len, const char* expected) {
     auto got = bytes_to_hex(data, len);
     if (g_generate) {
-        printf("    {\"%s\", \"%s\"},\n", label, got.c_str());
+        (void)printf("    {\"%s\", \"%s\"},\n", label, got.c_str());
         return;
     }
     char msg[128];
-    snprintf(msg, sizeof(msg), "%s mismatch", label);
+    (void)snprintf(msg, sizeof(msg), "%s mismatch", label);
     CHECK(got == expected, msg);
 }
 
@@ -123,7 +123,7 @@ static const KV FIELD_KAT[] = {
 
 static void test_field_kat() {
     g_section = "field_kat";
-    printf("[1] Field arithmetic KAT\n");
+    (void)printf("[1] Field arithmetic KAT\n");
 
     auto G = Point::generator();
     auto gx = G.x();
@@ -156,7 +156,7 @@ static void test_field_kat() {
 // ============================================================================
 static void test_scalar_kat() {
     g_section = "scalar_kat";
-    printf("[2] Scalar arithmetic KAT\n");
+    (void)printf("[2] Scalar arithmetic KAT\n");
 
     auto s1 = Scalar::from_bytes(PRIVKEY_BYTES);   // = 1
     auto s2 = Scalar::from_bytes(PRIVKEY2_BYTES);
@@ -164,7 +164,7 @@ static void test_scalar_kat() {
     auto sum = s1 + s2;
     auto sum_bytes = sum.to_bytes();
     if (g_generate) {
-        printf("    {\"s1+s2\", \"%s\"},\n", bytes_to_hex(sum_bytes.data(), 32).c_str());
+        (void)printf("    {\"s1+s2\", \"%s\"},\n", bytes_to_hex(sum_bytes.data(), 32).c_str());
     }
 
     auto prod = s1 * s2;
@@ -201,7 +201,7 @@ static const KV POINT_KAT[] = {
 
 static void test_point_kat() {
     g_section = "point_kat";
-    printf("[3] Point operation KAT\n");
+    (void)printf("[3] Point operation KAT\n");
 
     auto G = Point::generator();
     auto one_s = Scalar::from_bytes(PRIVKEY_BYTES);
@@ -228,8 +228,8 @@ static void test_point_kat() {
     auto ps2_comp = Ps2.to_compressed();
 
     if (g_generate) {
-        printf("    {\"s2G_comp\", \"%s\"},\n", bytes_to_hex(ps2_comp.data(), 33).c_str());
-        printf("    {\"s2G_uncomp\", \"%s\"},\n", bytes_to_hex(ps2_uncomp.data(), 65).c_str());
+        (void)printf("    {\"s2G_comp\", \"%s\"},\n", bytes_to_hex(ps2_comp.data(), 33).c_str());
+        (void)printf("    {\"s2G_uncomp\", \"%s\"},\n", bytes_to_hex(ps2_uncomp.data(), 65).c_str());
     }
 
     // Verify s2*G against golden vector
@@ -297,7 +297,7 @@ static void test_point_kat() {
 // ============================================================================
 static void test_ecdsa_kat() {
     g_section = "ecdsa_kat";
-    printf("[4] ECDSA KAT (RFC 6979 deterministic)\n");
+    (void)printf("[4] ECDSA KAT (RFC 6979 deterministic)\n");
 
     auto privkey = Scalar::from_bytes(PRIVKEY2_BYTES);
     auto pubkey = Point::generator().scalar_mul(privkey);
@@ -309,8 +309,8 @@ static void test_ecdsa_kat() {
     auto s_bytes = sig.s.to_bytes();
 
     if (g_generate) {
-        printf("    {\"ecdsa_r\", \"%s\"},\n", bytes_to_hex(r_bytes.data(), 32).c_str());
-        printf("    {\"ecdsa_s\", \"%s\"},\n", bytes_to_hex(s_bytes.data(), 32).c_str());
+        (void)printf("    {\"ecdsa_r\", \"%s\"},\n", bytes_to_hex(r_bytes.data(), 32).c_str());
+        (void)printf("    {\"ecdsa_s\", \"%s\"},\n", bytes_to_hex(s_bytes.data(), 32).c_str());
     }
 
     // Verify
@@ -333,7 +333,7 @@ static void test_ecdsa_kat() {
 // ============================================================================
 static void test_schnorr_kat() {
     g_section = "schnorr_kat";
-    printf("[5] Schnorr KAT (BIP-340 deterministic)\n");
+    (void)printf("[5] Schnorr KAT (BIP-340 deterministic)\n");
 
     auto privkey = Scalar::from_bytes(PRIVKEY2_BYTES);
 
@@ -342,10 +342,10 @@ static void test_schnorr_kat() {
     auto pubkey_x = secp256k1::schnorr_pubkey(privkey);
 
     if (g_generate) {
-        printf("    {\"schnorr_r\", \"%s\"},\n", bytes_to_hex(sig.r.data(), 32).c_str());
+        (void)printf("    {\"schnorr_r\", \"%s\"},\n", bytes_to_hex(sig.r.data(), 32).c_str());
         auto s_bytes = sig.s.to_bytes();
-        printf("    {\"schnorr_s\", \"%s\"},\n", bytes_to_hex(s_bytes.data(), 32).c_str());
-        printf("    {\"schnorr_pubkey_x\", \"%s\"},\n", bytes_to_hex(pubkey_x.data(), 32).c_str());
+        (void)printf("    {\"schnorr_s\", \"%s\"},\n", bytes_to_hex(s_bytes.data(), 32).c_str());
+        (void)printf("    {\"schnorr_pubkey_x\", \"%s\"},\n", bytes_to_hex(pubkey_x.data(), 32).c_str());
     }
 
     // Verify
@@ -368,7 +368,7 @@ static void test_schnorr_kat() {
 // ============================================================================
 static void test_serialization_kat() {
     g_section = "serial_kat";
-    printf("[6] Serialization consistency KAT\n");
+    (void)printf("[6] Serialization consistency KAT\n");
 
     auto privkey = Scalar::from_bytes(PRIVKEY2_BYTES);
     auto pubkey = Point::generator().scalar_mul(privkey);
@@ -383,10 +383,10 @@ static void test_serialization_kat() {
     auto compact = ecdsa_sig.to_compact();
 
     if (g_generate) {
-        printf("    {\"pubkey_comp\", \"%s\"},\n", bytes_to_hex(comp.data(), 33).c_str());
-        printf("    {\"pubkey_uncomp\", \"%s\"},\n", bytes_to_hex(uncomp.data(), 65).c_str());
-        printf("    {\"sig_compact\", \"%s\"},\n", bytes_to_hex(compact.data(), 64).c_str());
-        printf("    {\"sig_der\", \"%s\"},\n", bytes_to_hex(der_bytes.data(), der_len).c_str());
+        (void)printf("    {\"pubkey_comp\", \"%s\"},\n", bytes_to_hex(comp.data(), 33).c_str());
+        (void)printf("    {\"pubkey_uncomp\", \"%s\"},\n", bytes_to_hex(uncomp.data(), 65).c_str());
+        (void)printf("    {\"sig_compact\", \"%s\"},\n", bytes_to_hex(compact.data(), 64).c_str());
+        (void)printf("    {\"sig_der\", \"%s\"},\n", bytes_to_hex(der_bytes.data(), der_len).c_str());
     }
 
     // Compact round-trip
@@ -407,7 +407,7 @@ int test_cross_platform_kat_run() {
     test_ecdsa_kat();
     test_schnorr_kat();
     test_serialization_kat();
-    printf("  [cross_platform_kat] %d passed, %d failed\n", g_pass, g_fail);
+    (void)printf("  [cross_platform_kat] %d passed, %d failed\n", g_pass, g_fail);
     return g_fail > 0 ? 1 : 0;
 }
 
@@ -434,16 +434,16 @@ int main(int argc, char** argv) {
     for (int i = 1; i < argc; ++i) {
         if (std::string(argv[i]) == "--generate") {
             g_generate = true;
-            printf("// KAT Generator Mode -- copy these vectors into golden arrays\n");
-            printf("static const KV GOLDEN[] = {\n");
+            (void)printf("// KAT Generator Mode -- copy these vectors into golden arrays\n");
+            (void)printf("static const KV GOLDEN[] = {\n");
         }
     }
 
     if (!g_generate) {
-        printf("============================================================\n");
-        printf("  Cross-Platform KAT Equivalence Test\n");
-        printf("  Phase II, Tasks 2.6.3 / 2.6.4\n");
-        printf("============================================================\n\n");
+        (void)printf("============================================================\n");
+        (void)printf("  Cross-Platform KAT Equivalence Test\n");
+        (void)printf("  Phase II, Tasks 2.6.3 / 2.6.4\n");
+        (void)printf("============================================================\n\n");
     }
 
     test_field_kat();          if(!g_generate) printf("\n");
@@ -454,11 +454,11 @@ int main(int argc, char** argv) {
     test_serialization_kat();
 
     if (g_generate) {
-        printf("};\n");
+        (void)printf("};\n");
     } else {
-        printf("\n============================================================\n");
-        printf("  Summary: %d passed, %d failed\n", g_pass, g_fail);
-        printf("============================================================\n");
+        (void)printf("\n============================================================\n");
+        (void)printf("  Summary: %d passed, %d failed\n", g_pass, g_fail);
+        (void)printf("============================================================\n");
     }
 
     return g_fail > 0 ? 1 : 0;

--- a/audit/test_ct_sidechannel.cpp
+++ b/audit/test_ct_sidechannel.cpp
@@ -132,7 +132,7 @@ struct WelchState {
 // PRNG + helpers -- pre-generation only
 // ===========================================================================
 
-static std::mt19937_64 rng(0xA0D17'51DE0);
+static std::mt19937_64 rng(0xA0D17'51DE0);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
 
 static void random_bytes(uint8_t* out, size_t len) {
     for (size_t i = 0; i < len; i += 8) {
@@ -1103,7 +1103,7 @@ static void test_ct_utils() {
         WelchState ws;
         for (int i = 0; i < N; ++i) {
             int const cls = classes[i];
-            bool flag = flags[cls];
+            bool flag = flags[cls];  // NOLINT(misc-const-correctness) -- BARRIER_OPAQUE writes to flag
 
             BARRIER_OPAQUE(flag);
             uint64_t const t0 = rdtsc();
@@ -1134,7 +1134,7 @@ static void test_ct_utils() {
         WelchState ws;
         for (int i = 0; i < N; ++i) {
             int const cls = classes[i];
-            bool flag = flags[cls];
+            bool flag = flags[cls];  // NOLINT(misc-const-correctness) -- BARRIER_OPAQUE writes to flag
 
             BARRIER_OPAQUE(flag);
             uint64_t const t0 = rdtsc();

--- a/audit/test_debug_invariants.cpp
+++ b/audit/test_debug_invariants.cpp
@@ -32,7 +32,7 @@ static const char* g_section = "";
 
 #define CHECK(cond, msg) do { \
     if (!(cond)) { \
-        printf("  FAIL [%s]: %s (line %d)\n", g_section, msg, __LINE__); \
+        (void)printf("  FAIL [%s]: %s (line %d)\n", g_section, msg, __LINE__); \
         ++g_fail; \
     } else { \
         ++g_pass; \
@@ -44,7 +44,7 @@ static const char* g_section = "";
 // ============================================================================
 static void test_fe_normalization() {
     g_section = "fe_norm";
-    printf("[1] Field element normalization invariant\n");
+    (void)printf("[1] Field element normalization invariant\n");
 
     // Zero is normalized
     CHECK(debug::is_normalized_field_element(FieldElement::zero()),
@@ -62,12 +62,12 @@ static void test_fe_normalization() {
     }
 
     // random FE from proper constructors should always be normalized
-    std::mt19937_64 rng(42);
+    std::mt19937_64 rng(42);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     for (int i = 0; i < 100; ++i) {
         std::array<uint8_t, 32> bytes{};
         for (int j = 0; j < 4; ++j) {
             uint64_t v = rng();
-            std::memcpy(bytes.data() + j * 8, &v, 8);
+            std::memcpy(bytes.data() + static_cast<std::size_t>(j) * 8, &v, 8);
         }
         auto fe = FieldElement::from_bytes(bytes);
         CHECK(debug::is_normalized_field_element(fe),
@@ -83,7 +83,7 @@ static void test_fe_normalization() {
     CHECK(debug::is_normalized_field_element(a.square()), "sqr result normalized");
     CHECK(debug::is_normalized_field_element(a.inverse()), "inv result normalized");
 
-    printf("    -> all FE normalization checks passed\n");
+    (void)printf("    -> all FE normalization checks passed\n");
 }
 
 // ============================================================================
@@ -91,7 +91,7 @@ static void test_fe_normalization() {
 // ============================================================================
 static void test_on_curve() {
     g_section = "on_curve";
-    printf("[2] Point on-curve invariant\n");
+    (void)printf("[2] Point on-curve invariant\n");
 
     // Generator must be on curve
     CHECK(debug::is_on_curve(Point::generator()), "G must be on curve");
@@ -100,12 +100,12 @@ static void test_on_curve() {
     CHECK(debug::is_on_curve(Point::infinity()), "O must be on curve");
 
     // Random scalar multiples of G must be on curve
-    std::mt19937_64 rng(123);
+    std::mt19937_64 rng(123);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     for (int i = 0; i < 50; ++i) {
         std::array<uint8_t, 32> bytes{};
         for (int j = 0; j < 4; ++j) {
             uint64_t v = rng();
-            std::memcpy(bytes.data() + j * 8, &v, 8);
+            std::memcpy(bytes.data() + static_cast<std::size_t>(j) * 8, &v, 8);
         }
         auto s = Scalar::from_bytes(bytes);
         if (s.is_zero()) continue;
@@ -127,7 +127,7 @@ static void test_on_curve() {
     Point const P5 = P1.negate();
     CHECK(debug::is_on_curve(P5), "-P must be on curve");
 
-    printf("    -> all on-curve checks passed\n");
+    (void)printf("    -> all on-curve checks passed\n");
 }
 
 // ============================================================================
@@ -135,7 +135,7 @@ static void test_on_curve() {
 // ============================================================================
 static void test_scalar_valid() {
     g_section = "scalar_valid";
-    printf("[3] Scalar validity invariant\n");
+    (void)printf("[3] Scalar validity invariant\n");
 
     // Zero is NOT valid (for signing/mul purposes)
     CHECK(!debug::is_valid_scalar(Scalar::zero()), "zero must not be 'valid'");
@@ -144,12 +144,12 @@ static void test_scalar_valid() {
     CHECK(debug::is_valid_scalar(Scalar::one()), "one must be valid");
 
     // Random scalars from proper constructors
-    std::mt19937_64 rng(456);
+    std::mt19937_64 rng(456);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     for (int i = 0; i < 100; ++i) {
         std::array<uint8_t, 32> bytes{};
         for (int j = 0; j < 4; ++j) {
             uint64_t v = rng();
-            std::memcpy(bytes.data() + j * 8, &v, 8);
+            std::memcpy(bytes.data() + static_cast<std::size_t>(j) * 8, &v, 8);
         }
         auto s = Scalar::from_bytes(bytes);
         if (s.is_zero()) continue;
@@ -164,7 +164,7 @@ static void test_scalar_valid() {
     CHECK(debug::is_valid_scalar(a.inverse()), "a^-1 must be valid");
     CHECK(debug::is_valid_scalar(a.negate()), "-a must be valid");
 
-    printf("    -> all scalar validity checks passed\n");
+    (void)printf("    -> all scalar validity checks passed\n");
 }
 
 // ============================================================================
@@ -172,7 +172,7 @@ static void test_scalar_valid() {
 // ============================================================================
 static void test_macro_integration() {
     g_section = "macros";
-    printf("[4] Debug assertion macro integration\n");
+    (void)printf("[4] Debug assertion macro integration\n");
 
     // Reset counter
     auto& c = debug::counters();
@@ -195,7 +195,7 @@ static void test_macro_integration() {
     SECP_ASSERT(1 + 1 == 2);
     SECP_ASSERT_MSG(true, "this should not fail");
 
-    printf("    -> all macros work correctly\n");
+    (void)printf("    -> all macros work correctly\n");
 }
 
 // ============================================================================
@@ -203,7 +203,7 @@ static void test_macro_integration() {
 // ============================================================================
 static void test_full_chain() {
     g_section = "full_chain";
-    printf("[5] Full computation chain with invariant checks\n");
+    (void)printf("[5] Full computation chain with invariant checks\n");
 
     auto k = Scalar::from_uint64(0xABCDEF);
     SECP_ASSERT_SCALAR_VALID(k);
@@ -237,7 +237,7 @@ static void test_full_chain() {
     auto x3 = (x.square() * x) + FieldElement::from_uint64(7);
     CHECK(y2 == x3, "curve equation must hold");
 
-    printf("    -> full chain invariants passed\n");
+    (void)printf("    -> full chain invariants passed\n");
 }
 
 // ============================================================================
@@ -245,11 +245,11 @@ static void test_full_chain() {
 // ============================================================================
 static void test_debug_counters() {
     g_section = "counters";
-    printf("[6] Debug counter accumulation\n");
+    (void)printf("[6] Debug counter accumulation\n");
 
     auto& c = debug::counters();
     CHECK(c.invariant_check_count > 0, "invariant counter must have accumulated");
-    printf("    -> %llu invariant checks performed so far\n",
+    (void)printf("    -> %llu invariant checks performed so far\n",
            (unsigned long long)c.invariant_check_count);
 }
 
@@ -264,7 +264,7 @@ int test_debug_invariants_run() {
     test_macro_integration();
     test_full_chain();
     test_debug_counters();
-    printf("  [debug_invariants] %d passed, %d failed\n", g_pass, g_fail);
+    (void)printf("  [debug_invariants] %d passed, %d failed\n", g_pass, g_fail);
     return g_fail > 0 ? 1 : 0;
 }
 
@@ -273,26 +273,26 @@ int test_debug_invariants_run() {
 // ============================================================================
 #ifndef UNIFIED_AUDIT_RUNNER
 int main() {
-    printf("============================================================\n");
-    printf("  Debug Invariant Assertions Test\n");
-    printf("  Phase V, Task 5.3.3\n");
-    printf("============================================================\n\n");
+    (void)printf("============================================================\n");
+    (void)printf("  Debug Invariant Assertions Test\n");
+    (void)printf("  Phase V, Task 5.3.3\n");
+    (void)printf("============================================================\n\n");
 
     test_fe_normalization();
-    printf("\n");
+    (void)printf("\n");
     test_on_curve();
-    printf("\n");
+    (void)printf("\n");
     test_scalar_valid();
-    printf("\n");
+    (void)printf("\n");
     test_macro_integration();
-    printf("\n");
+    (void)printf("\n");
     test_full_chain();
-    printf("\n");
+    (void)printf("\n");
     test_debug_counters();
 
-    printf("\n============================================================\n");
-    printf("  Summary: %d passed, %d failed\n", g_pass, g_fail);
-    printf("============================================================\n");
+    (void)printf("\n============================================================\n");
+    (void)printf("  Summary: %d passed, %d failed\n", g_pass, g_fail);
+    (void)printf("============================================================\n");
 
     // Print counter report
     SECP_DEBUG_COUNTER_REPORT();

--- a/audit/test_fault_injection.cpp
+++ b/audit/test_fault_injection.cpp
@@ -33,21 +33,21 @@ static int g_pass = 0, g_fail = 0;
 static const char* g_section = "";
 
 #define CHECK(cond, msg) do { \
-    if (!(cond)) { \
+    if (cond) { \
+        ++g_pass; \
+    } else { \
         printf("  FAIL [%s]: %s (line %d)\n", g_section, msg, __LINE__); \
         ++g_fail; \
-    } else { \
-        ++g_pass; \
     } \
 } while(0)
 
-static std::mt19937_64 rng(0xFA017'10EC7ULL);
+static std::mt19937_64 rng(0xFA017'10EC7ULL);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
 
 static Scalar random_scalar() {
     std::array<uint8_t, 32> out{};
     for (int i = 0; i < 4; ++i) {
         uint64_t v = rng();
-        std::memcpy(out.data() + i * 8, &v, 8);
+        std::memcpy(out.data() + static_cast<std::size_t>(i) * 8, &v, 8);
     }
     for (;;) {
         auto s = Scalar::from_bytes(out);
@@ -60,7 +60,7 @@ static std::array<uint8_t, 32> random_message() {
     std::array<uint8_t, 32> msg{};
     for (int i = 0; i < 4; ++i) {
         uint64_t v = rng();
-        std::memcpy(msg.data() + i * 8, &v, 8);
+        std::memcpy(msg.data() + static_cast<std::size_t>(i) * 8, &v, 8);
     }
     return msg;
 }
@@ -223,7 +223,7 @@ static void test_schnorr_signature_fault() {
         std::array<uint8_t, 32> aux_rand{};
         for (int j = 0; j < 4; ++j) {
             uint64_t v = rng();
-            std::memcpy(aux_rand.data() + j * 8, &v, 8);
+            std::memcpy(aux_rand.data() + static_cast<std::size_t>(j) * 8, &v, 8);
         }
 
         auto sig = secp256k1::schnorr_sign(privkey, msg, aux_rand);
@@ -262,7 +262,7 @@ static void test_ct_fault_resilience() {
         std::array<uint8_t, 32> a{}, b{};
         for (int j = 0; j < 4; ++j) {
             uint64_t v = rng();
-            std::memcpy(a.data() + j * 8, &v, 8);
+            std::memcpy(a.data() + static_cast<std::size_t>(j) * 8, &v, 8);
         }
         b = a;
 
@@ -286,7 +286,7 @@ static void test_ct_fault_resilience() {
         std::array<uint8_t, 32> a{};
         for (int j = 0; j < 4; ++j) {
             uint64_t v = rng();
-            std::memcpy(a.data() + j * 8, &v, 8);
+            std::memcpy(a.data() + static_cast<std::size_t>(j) * 8, &v, 8);
         }
         int const cmp = secp256k1::ct::ct_compare(a.data(), a.data(), 32);
         CHECK(cmp == 0, "ct_compare(x,x) must be 0");

--- a/audit/test_fiat_crypto_vectors.cpp
+++ b/audit/test_fiat_crypto_vectors.cpp
@@ -31,7 +31,7 @@ static const char* g_section = "";
 
 #define CHECK(cond, msg) do { \
     if (!(cond)) { \
-        printf("  FAIL [%s]: %s (line %d)\n", g_section, msg, __LINE__); \
+        (void)printf("  FAIL [%s]: %s (line %d)\n", g_section, msg, __LINE__); \
         ++g_fail; \
     } else { \
         ++g_pass; \
@@ -43,8 +43,8 @@ static FieldElement fe_from_hex(const char* hex64) {
     std::array<uint8_t, 32> bytes{};
     for (int i = 0; i < 32; ++i) {
         unsigned hi, lo;
-        sscanf(hex64 + i * 2, "%1x", &hi);
-        sscanf(hex64 + i * 2 + 1, "%1x", &lo);
+        (void)sscanf(hex64 + static_cast<std::size_t>(i) * 2, "%1x", &hi);
+        (void)sscanf(hex64 + static_cast<std::size_t>(i) * 2 + 1, "%1x", &lo);
         bytes[i] = static_cast<uint8_t>((hi << 4) | lo);
     }
     return FieldElement::from_bytes(bytes);
@@ -54,8 +54,8 @@ static Scalar scalar_from_hex(const char* hex64) {
     std::array<uint8_t, 32> bytes{};
     for (int i = 0; i < 32; ++i) {
         unsigned hi, lo;
-        sscanf(hex64 + i * 2, "%1x", &hi);
-        sscanf(hex64 + i * 2 + 1, "%1x", &lo);
+        (void)sscanf(hex64 + static_cast<std::size_t>(i) * 2, "%1x", &hi);
+        (void)sscanf(hex64 + static_cast<std::size_t>(i) * 2 + 1, "%1x", &lo);
         bytes[i] = static_cast<uint8_t>((hi << 4) | lo);
     }
     return Scalar::from_bytes(bytes);
@@ -130,14 +130,14 @@ static const MulVector MUL_VECTORS[] = {
 
 static void test_mul_vectors() {
     g_section = "fiat_mul";
-    printf("[1] Field multiplication golden vectors (Fiat-Crypto/Sage)\n");
+    (void)printf("[1] Field multiplication golden vectors (Fiat-Crypto/Sage)\n");
 
     for (int i = 0; i < (int)(sizeof(MUL_VECTORS) / sizeof(MUL_VECTORS[0])); ++i) {
         auto a = fe_from_hex(MUL_VECTORS[i].a);
         auto b = fe_from_hex(MUL_VECTORS[i].b);
         auto result = a * b;
         char msg[64];
-        snprintf(msg, sizeof(msg), "mul_vec[%d]", i);
+        (void)snprintf(msg, sizeof(msg), "mul_vec[%d]", i);
         CHECK(fe_equals_hex(result, MUL_VECTORS[i].expected), msg);
     }
 }
@@ -170,13 +170,13 @@ static const SqrVector SQR_VECTORS[] = {
 
 static void test_sqr_vectors() {
     g_section = "fiat_sqr";
-    printf("[2] Field squaring golden vectors\n");
+    (void)printf("[2] Field squaring golden vectors\n");
 
     for (int i = 0; i < (int)(sizeof(SQR_VECTORS) / sizeof(SQR_VECTORS[0])); ++i) {
         auto a = fe_from_hex(SQR_VECTORS[i].a);
         auto result = a.square();
         char msg[64];
-        snprintf(msg, sizeof(msg), "sqr_vec[%d]", i);
+        (void)snprintf(msg, sizeof(msg), "sqr_vec[%d]", i);
         CHECK(fe_equals_hex(result, SQR_VECTORS[i].expected), msg);
     }
 }
@@ -214,7 +214,7 @@ static const InvVector INV_VECTORS[] = {
 
 static void test_inv_vectors() {
     g_section = "fiat_inv";
-    printf("[3] Field inversion golden vectors\n");
+    (void)printf("[3] Field inversion golden vectors\n");
 
     for (int i = 0; i < (int)(sizeof(INV_VECTORS) / sizeof(INV_VECTORS[0])); ++i) {
         auto a = fe_from_hex(INV_VECTORS[i].a);
@@ -223,7 +223,7 @@ static void test_inv_vectors() {
         // Cross-check: a * a^(-1) == 1
         auto check = a * result;
         char msg[64];
-        snprintf(msg, sizeof(msg), "inv_roundtrip[%d]", i);
+        (void)snprintf(msg, sizeof(msg), "inv_roundtrip[%d]", i);
         CHECK(fe_equals_hex(check, "0000000000000000000000000000000000000000000000000000000000000001"), msg);
     }
 }
@@ -233,7 +233,7 @@ static void test_inv_vectors() {
 // ============================================================================
 static void test_add_sub_vectors() {
     g_section = "fiat_add_sub";
-    printf("[4] Field add/sub boundary vectors\n");
+    (void)printf("[4] Field add/sub boundary vectors\n");
 
     auto zero = FieldElement::zero();
     auto one = FieldElement::one();
@@ -271,7 +271,7 @@ static void test_add_sub_vectors() {
 // ============================================================================
 static void test_scalar_vectors() {
     g_section = "fiat_scalar";
-    printf("[5] Scalar arithmetic golden vectors (group order n)\n");
+    (void)printf("[5] Scalar arithmetic golden vectors (group order n)\n");
 
     auto one = Scalar::from_bytes({0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1});
     auto zero = Scalar::from_bytes({0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0});
@@ -308,7 +308,7 @@ static void test_scalar_vectors() {
 // ============================================================================
 static void test_point_vectors() {
     g_section = "fiat_point";
-    printf("[6] Point arithmetic golden vectors\n");
+    (void)printf("[6] Point arithmetic golden vectors\n");
 
     auto G = Point::generator();
 
@@ -357,7 +357,7 @@ static void test_point_vectors() {
 // ============================================================================
 static void test_algebraic_identities() {
     g_section = "fiat_algebraic";
-    printf("[7] Algebraic identity verification (100 rounds)\n");
+    (void)printf("[7] Algebraic identity verification (100 rounds)\n");
 
     // Deterministic PRNG
     std::array<uint8_t, 32> seed{};
@@ -410,7 +410,7 @@ static void test_algebraic_identities() {
 // ============================================================================
 static void test_serialization_roundtrip() {
     g_section = "fiat_serial";
-    printf("[8] Serialization round-trip consistency\n");
+    (void)printf("[8] Serialization round-trip consistency\n");
 
     // Known values
     const char* test_values[] = {
@@ -450,7 +450,7 @@ int test_fiat_crypto_vectors_run() {
     test_point_vectors();
     test_algebraic_identities();
     test_serialization_roundtrip();
-    printf("  [fiat_crypto_vectors] %d passed, %d failed\n", g_pass, g_fail);
+    (void)printf("  [fiat_crypto_vectors] %d passed, %d failed\n", g_pass, g_fail);
     return g_fail > 0 ? 1 : 0;
 }
 
@@ -458,10 +458,10 @@ int test_fiat_crypto_vectors_run() {
 // ============================================================================
 #ifndef UNIFIED_AUDIT_RUNNER
 int main() {
-    printf("============================================================\n");
-    printf("  Fiat-Crypto Reference Vector Comparison Test\n");
-    printf("  Phase V, Task 5.3.1\n");
-    printf("============================================================\n\n");
+    (void)printf("============================================================\n");
+    (void)printf("  Fiat-Crypto Reference Vector Comparison Test\n");
+    (void)printf("  Phase V, Task 5.3.1\n");
+    (void)printf("============================================================\n\n");
 
     test_mul_vectors();      printf("\n");
     test_sqr_vectors();      printf("\n");
@@ -472,9 +472,9 @@ int main() {
     test_algebraic_identities(); printf("\n");
     test_serialization_roundtrip();
 
-    printf("\n============================================================\n");
-    printf("  Summary: %d passed, %d failed\n", g_pass, g_fail);
-    printf("============================================================\n");
+    (void)printf("\n============================================================\n");
+    (void)printf("  Summary: %d passed, %d failed\n", g_pass, g_fail);
+    (void)printf("============================================================\n");
 
     return g_fail > 0 ? 1 : 0;
 }

--- a/audit/test_frost_kat.cpp
+++ b/audit/test_frost_kat.cpp
@@ -33,7 +33,6 @@
 
 using secp256k1::fast::Scalar;
 using secp256k1::fast::Point;
-using secp256k1::fast::FieldElement;
 
 // -- Minimal test harness -----------------------------------------------------
 
@@ -43,7 +42,7 @@ static int g_fail = 0;
 #define CHECK(cond, label) do { \
     if (cond) { ++g_pass; } else { \
         ++g_fail; \
-        std::printf("  FAIL: %s (line %d)\n", label, __LINE__); \
+        (void)std::printf("  FAIL: %s (line %d)\n", label, __LINE__); \
     } \
 } while(0)
 
@@ -65,7 +64,7 @@ static bool points_equal(const Point& a, const Point& b) {
 // ===============================================================================
 
 static void test_lagrange_properties() {
-    std::printf("[1] Lagrange Coefficient: Mathematical Properties\n");
+    (void)std::printf("[1] Lagrange Coefficient: Mathematical Properties\n");
 
     // Property 1: For signer set {1,2} with 2-of-2:
     //   lambda_1 = 2/(2-1) = 2
@@ -165,7 +164,7 @@ static void test_lagrange_properties() {
 // ===============================================================================
 
 static void test_dkg_determinism() {
-    std::printf("[2] FROST DKG: Determinism with Fixed Seeds\n");
+    (void)std::printf("[2] FROST DKG: Determinism with Fixed Seeds\n");
 
     const uint32_t t = 2, n = 3;
     auto seed1 = make_seed(0xF205E001);
@@ -213,7 +212,7 @@ static void test_dkg_determinism() {
 // ===============================================================================
 
 static void test_dkg_feldman_vss() {
-    std::printf("[3] FROST DKG: Feldman VSS Commitment Verification\n");
+    (void)std::printf("[3] FROST DKG: Feldman VSS Commitment Verification\n");
 
     const uint32_t t = 2, n = 3;
 
@@ -262,7 +261,7 @@ static void test_dkg_feldman_vss() {
 // ===============================================================================
 
 static void test_2of3_full_signing() {
-    std::printf("[4] FROST 2-of-3: Full Signing -> BIP-340 Verify\n");
+    (void)std::printf("[4] FROST 2-of-3: Full Signing -> BIP-340 Verify\n");
 
     const uint32_t t = 2, n = 3;
 
@@ -330,7 +329,7 @@ static void test_2of3_full_signing() {
         bool const valid = secp256k1::schnorr_verify(pk_bytes, msg, final_sig);
 
         char label[64];
-        std::snprintf(label, sizeof(label), "2-of-3 subset {%u,%u} BIP-340 valid", id_a, id_b);
+        (void)std::snprintf(label, sizeof(label), "2-of-3 subset {%u,%u} BIP-340 valid", id_a, id_b);
         CHECK(valid, label);
     }
 }
@@ -340,7 +339,7 @@ static void test_2of3_full_signing() {
 // ===============================================================================
 
 static void test_3of5_full_signing() {
-    std::printf("[5] FROST 3-of-5: Full Signing -> BIP-340 Verify\n");
+    (void)std::printf("[5] FROST 3-of-5: Full Signing -> BIP-340 Verify\n");
 
     const uint32_t t = 3, n = 5;
 
@@ -353,8 +352,8 @@ static void test_3of5_full_signing() {
 
     for (uint32_t i = 1; i <= n; ++i) {
         auto [ci, si] = secp256k1::frost_keygen_begin(i, t, n, seeds[i - 1]);
-        commitments.push_back(std::move(ci));
-        all_shares.push_back(std::move(si));
+        commitments.push_back(ci);
+        all_shares.push_back(si);
     }
 
     // DKG Round 2
@@ -367,7 +366,7 @@ for (uint32_t from = 0; from < n; ++from) {
         }
         auto [kp, ok] = secp256k1::frost_keygen_finalize(i, commitments, received, t, n);
         CHECK(ok, "3-of-5 DKG finalize");
-        key_pkgs.push_back(std::move(kp));
+        key_pkgs.push_back(kp);
     }
 
     // All agree on group key
@@ -390,8 +389,8 @@ for (uint32_t from = 0; from < n; ++from) {
     for (auto id : signer_ids) {
         auto nonce_seed = make_seed(0x30500000 + id);
         auto [nc, cm] = secp256k1::frost_sign_nonce_gen(id, nonce_seed);
-        nonces.push_back(std::move(nc));
-        nonce_commits.push_back(std::move(cm));
+        nonces.push_back(nc);
+        nonce_commits.push_back(cm);
     }
 
     // Partial signatures
@@ -399,7 +398,7 @@ for (uint32_t from = 0; from < n; ++from) {
     for (size_t i = 0; i < signer_ids.size(); ++i) {
         auto psig = secp256k1::frost_sign(
             key_pkgs[signer_ids[i] - 1], nonces[i], msg, nonce_commits);
-        partials.push_back(std::move(psig));
+        partials.push_back(psig);
     }
 
     // Aggregate
@@ -418,15 +417,15 @@ for (uint32_t from = 0; from < n; ++from) {
     for (auto id : signer_ids) {
         auto nonce_seed = make_seed(0x30520000 + id);
         auto [nc, cm] = secp256k1::frost_sign_nonce_gen(id, nonce_seed);
-        nonces.push_back(std::move(nc));
-        nonce_commits.push_back(std::move(cm));
+        nonces.push_back(nc);
+        nonce_commits.push_back(cm);
     }
 
     partials.clear();
     for (size_t i = 0; i < signer_ids.size(); ++i) {
         auto psig = secp256k1::frost_sign(
             key_pkgs[signer_ids[i] - 1], nonces[i], msg, nonce_commits);
-        partials.push_back(std::move(psig));
+        partials.push_back(psig);
     }
 
     auto final_sig2 = secp256k1::frost_aggregate(
@@ -447,7 +446,7 @@ for (uint32_t from = 0; from < n; ++from) {
 // ===============================================================================
 
 static void test_lagrange_consistency() {
-    std::printf("[6] Lagrange Coefficients: Consistency Across 10 Subsets\n");
+    (void)std::printf("[6] Lagrange Coefficients: Consistency Across 10 Subsets\n");
 
     // For a 3-of-5 scheme: all C(5,3) = 10 subsets reconstruct same secret
     // Polynomial f(x) = 17 + 3x + 5x^2
@@ -478,7 +477,7 @@ static void test_lagrange_consistency() {
                            + (l2 * shares[ids[2] - 1]);
 
         char label[80];
-        std::snprintf(label, sizeof(label), "3-of-5 subset {%u,%u,%u} reconstructs secret",
+        (void)std::snprintf(label, sizeof(label), "3-of-5 subset {%u,%u,%u} reconstructs secret",
                       ids[0], ids[1], ids[2]);
         CHECK(reconstructed == secret, label);
     }
@@ -489,7 +488,7 @@ static void test_lagrange_consistency() {
 // ===============================================================================
 
 static void test_pinned_dkg_group_key() {
-    std::printf("[7] Pinned KAT: DKG Group Key Determinism\n");
+    (void)std::printf("[7] Pinned KAT: DKG Group Key Determinism\n");
 
     const uint32_t t = 2, n = 3;
 
@@ -531,7 +530,7 @@ static void test_pinned_dkg_group_key() {
 // ===============================================================================
 
 static void test_pinned_signing_roundtrip() {
-    std::printf("[8] Pinned KAT: Full Signing Round-Trip Determinism\n");
+    (void)std::printf("[8] Pinned KAT: Full Signing Round-Trip Determinism\n");
 
     const uint32_t t = 2, n = 3;
     auto seed1 = make_seed(0x51670001);
@@ -589,7 +588,7 @@ static void test_pinned_signing_roundtrip() {
 // ===============================================================================
 
 static void test_secret_reconstruction() {
-    std::printf("[9] FROST DKG: Secret Reconstruction via Lagrange\n");
+    (void)std::printf("[9] FROST DKG: Secret Reconstruction via Lagrange\n");
 
     const uint32_t t = 2, n = 3;
     auto seed1 = make_seed(0xEE000001);
@@ -661,7 +660,7 @@ int test_frost_kat_run() {
 
 #ifndef UNIFIED_AUDIT_RUNNER
 int main() {
-    std::printf("=== FROST Reference KAT Tests (Phase II 2.2.5) ===\n\n");
+    (void)std::printf("=== FROST Reference KAT Tests (Phase II 2.2.5) ===\n\n");
 
     test_lagrange_properties();
     test_dkg_determinism();
@@ -673,13 +672,13 @@ int main() {
     test_pinned_signing_roundtrip();
     test_secret_reconstruction();
 
-    std::printf("\n=== Results: %d passed, %d failed ===\n", g_pass, g_fail);
+    (void)std::printf("\n=== Results: %d passed, %d failed ===\n", g_pass, g_fail);
 
     if (g_fail > 0) {
-        std::printf("*** %d FAILURES ***\n", g_fail);
+        (void)std::printf("*** %d FAILURES ***\n", g_fail);
         return 1;
     }
-    std::printf("All reference KAT checks passed.\n");
+    (void)std::printf("All reference KAT checks passed.\n");
     return 0;
 }
 #endif // UNIFIED_AUDIT_RUNNER

--- a/audit/test_fuzz_address_bip32_ffi.cpp
+++ b/audit/test_fuzz_address_bip32_ffi.cpp
@@ -37,11 +37,11 @@ static int g_fail = 0;
 static int g_crash = 0;  // should stay 0
 
 #define CHECK(cond, msg) do { \
-    if (!(cond)) { \
+    if (cond) { \
+        ++g_pass; \
+    } else { \
         std::printf("  FAIL: %s (line %d)\n", (msg), __LINE__); \
         ++g_fail; \
-    } else { \
-        ++g_pass; \
     } \
 } while(0)
 
@@ -50,7 +50,7 @@ static int g_crash = 0;  // should stay 0
     ++g_pass; \
 } while(0)
 
-static std::mt19937_64 rng(0xADD12E55);
+static std::mt19937_64 rng(0xADD12E55);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
 
 static void fill_random(uint8_t* buf, size_t len) {
     for (size_t i = 0; i < len; ++i) {
@@ -877,7 +877,9 @@ static void suite_13_ffi_error_inspection(ufsecp_ctx* ctx) {
     // 13a: All defined error codes have a string
     for (int code = 0; code <= 10; ++code) {
         const char* str = ufsecp_error_str(static_cast<ufsecp_error_t>(code));
+        // cppcheck-suppress nullPointerRedundantCheck
         CHECK(str != nullptr, "error_str_not_null");
+        // cppcheck-suppress nullPointerRedundantCheck
         CHECK(std::strlen(str) > 0, "error_str_not_empty");
     }
 

--- a/audit/test_fuzz_parsers.cpp
+++ b/audit/test_fuzz_parsers.cpp
@@ -51,7 +51,7 @@ static int g_fail  = 0;
     ++g_pass; \
 } while(0)
 
-static std::mt19937_64 rng(0xDEADBEEF);
+static std::mt19937_64 rng(0xDEADBEEF);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
 
 static std::vector<uint8_t> random_blob(size_t max_len) {
     std::uniform_int_distribution<size_t> len_dist(0, max_len);
@@ -65,7 +65,7 @@ static std::array<uint8_t, 32> random32() {
     std::array<uint8_t, 32> out{};
     for (int i = 0; i < 4; ++i) {
         uint64_t v = rng();
-        std::memcpy(out.data() + i * 8, &v, 8);
+        std::memcpy(out.data() + static_cast<std::size_t>(i) * 8, &v, 8);
     }
     return out;
 }

--- a/audit/test_musig2_frost.cpp
+++ b/audit/test_musig2_frost.cpp
@@ -31,7 +31,6 @@
 
 using secp256k1::fast::Scalar;
 using secp256k1::fast::Point;
-using secp256k1::fast::FieldElement;
 
 // -- Minimal test harness -----------------------------------------------------
 
@@ -51,7 +50,7 @@ static std::array<uint8_t, 32> random32(std::mt19937_64& rng) {
     std::array<uint8_t, 32> out{};
     for (int i = 0; i < 4; ++i) {
         uint64_t v = rng();
-        std::memcpy(out.data() + i * 8, &v, 8);
+        std::memcpy(out.data() + static_cast<std::size_t>(i) * 8, &v, 8);
     }
     return out;
 }
@@ -80,7 +79,7 @@ static std::array<uint8_t, 32> xonly_pubkey(const Scalar& sk) {
 static void test_musig2_key_agg_determinism() {
     std::printf("[1] MuSig2 Key Aggregation: Determinism\n");
 
-    std::mt19937_64 rng(0xDEADBEEF);
+    std::mt19937_64 rng(0xDEADBEEF);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int N = 50;
 
     for (int round = 0; round < N; ++round) {
@@ -113,7 +112,7 @@ static void test_musig2_key_agg_determinism() {
 static void test_musig2_key_agg_ordering() {
     std::printf("[2] MuSig2 Key Aggregation: Ordering Matters\n");
 
-    std::mt19937_64 rng(0xCAFEBABE);
+    std::mt19937_64 rng(0xCAFEBABE);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int N = 20;
 
     for (int round = 0; round < N; ++round) {
@@ -145,7 +144,7 @@ for (int i = 0; i < 3; ++i) {
 static void test_musig2_key_agg_duplicates() {
     std::printf("[3] MuSig2 Key Aggregation: Duplicate Keys\n");
 
-    std::mt19937_64 rng(0x12345678);
+    std::mt19937_64 rng(0x12345678);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     auto sk = random_privkey(rng);
     auto pk = xonly_pubkey(sk);
 
@@ -172,7 +171,7 @@ static void test_musig2_key_agg_duplicates() {
 static void test_musig2_round_trip(int n_signers, const char* label) {
     std::printf("[4.%s] MuSig2 Full Round-Trip: %d signers\n", label, n_signers);
 
-    std::mt19937_64 rng(0xBEEF0000 + static_cast<uint32_t>(n_signers));
+    std::mt19937_64 rng(0xBEEF0000 + static_cast<uint32_t>(n_signers));  // NOLINT(cert-msc32-c,cert-msc51-cpp)
 
     const int ROUNDS = 20;
     for (int round = 0; round < ROUNDS; ++round) {
@@ -239,7 +238,7 @@ static void test_musig2_round_trip(int n_signers, const char* label) {
 static void test_musig2_wrong_signer() {
     std::printf("[5] MuSig2: Wrong Partial Sig Fails Verify\n");
 
-    std::mt19937_64 rng(0xBAADF00D);
+    std::mt19937_64 rng(0xBAADF00D);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int N = 10;
 
     for (int round = 0; round < N; ++round) {
@@ -283,7 +282,7 @@ static void test_musig2_wrong_signer() {
 static void test_musig2_bitflip() {
     std::printf("[6] MuSig2: Bit-Flip Invalidates Final Signature\n");
 
-    std::mt19937_64 rng(0xFACEFEED);
+    std::mt19937_64 rng(0xFACEFEED);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int N = 20;
 
     for (int round = 0; round < N; ++round) {
@@ -346,7 +345,7 @@ static void test_frost_dkg(uint32_t threshold, uint32_t n_participants,
                            const char* label) {
     std::printf("[7.%s] FROST DKG: %u-of-%u\n", label, threshold, n_participants);
 
-    std::mt19937_64 rng(0xF0057000 + threshold * 100 + n_participants);
+    std::mt19937_64 rng(0xF0057000 + threshold * 100 + n_participants);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int ROUNDS = 10;
 
     for (int round = 0; round < ROUNDS; ++round) {
@@ -408,7 +407,7 @@ static void test_frost_signing(uint32_t threshold, uint32_t n_participants,
                                const char* label) {
     std::printf("[8.%s] FROST Signing: %u-of-%u\n", label, threshold, n_participants);
 
-    std::mt19937_64 rng(0xF5160000 + threshold * 100 + n_participants);
+    std::mt19937_64 rng(0xF5160000 + threshold * 100 + n_participants);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int ROUNDS = 10;
 
     for (int round = 0; round < ROUNDS; ++round) {
@@ -503,7 +502,7 @@ for (uint32_t i = 0; i < threshold; ++i) {
 static void test_frost_different_subsets() {
     std::printf("[9] FROST: Different 2-of-3 Subsets All Valid\n");
 
-    std::mt19937_64 rng(0xF5AB5E70);
+    std::mt19937_64 rng(0xF5AB5E70);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int ROUNDS = 5;
 
     for (int round = 0; round < ROUNDS; ++round) {
@@ -573,7 +572,7 @@ for (uint32_t j = 0; j < n_parts; ++j) {
 static void test_frost_bitflip() {
     std::printf("[10] FROST: Bit-Flip Invalidates Signature\n");
 
-    std::mt19937_64 rng(0xF5B17F11);
+    std::mt19937_64 rng(0xF5B17F11);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int N = 10;
 
     for (int round = 0; round < N; ++round) {
@@ -627,7 +626,7 @@ for (uint32_t j = 0; j < n; ++j) ms.push_back(smatrix[j][i]);
 static void test_frost_wrong_partial() {
     std::printf("[11] FROST: Wrong Partial Sig Fails Verify\n");
 
-    std::mt19937_64 rng(0xF5BAD510);
+    std::mt19937_64 rng(0xF5BAD510);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int N = 10;
 
     for (int round = 0; round < N; ++round) {

--- a/audit/test_musig2_frost_advanced.cpp
+++ b/audit/test_musig2_frost_advanced.cpp
@@ -24,7 +24,6 @@
 
 using secp256k1::fast::Scalar;
 using secp256k1::fast::Point;
-using secp256k1::fast::FieldElement;
 
 // -- Minimal test harness -----------------------------------------------------
 
@@ -44,7 +43,7 @@ static std::array<uint8_t, 32> random32(std::mt19937_64& rng) {
     std::array<uint8_t, 32> out{};
     for (int i = 0; i < 4; ++i) {
         uint64_t v = rng();
-        std::memcpy(out.data() + i * 8, &v, 8);
+        std::memcpy(out.data() + static_cast<std::size_t>(i) * 8, &v, 8);
     }
     return out;
 }
@@ -107,7 +106,7 @@ for (int i = 0; i < n; ++i) {
 static void test_musig2_rogue_key_resistance() {
     std::printf("[1] MuSig2: Rogue-Key Resistance\n");
 
-    std::mt19937_64 rng(0xD0AEFACE);
+    std::mt19937_64 rng(0xD0AEFACE);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int N = 10;
 
     for (int round = 0; round < N; ++round) {
@@ -166,7 +165,7 @@ static void test_musig2_rogue_key_resistance() {
 static void test_musig2_key_coefficient_binding() {
     std::printf("[2] MuSig2: Key Coefficient Depends on Full Group\n");
 
-    std::mt19937_64 rng(0xC0EFF1C1);
+    std::mt19937_64 rng(0xC0EFF1C1);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int N = 10;
 
     for (int round = 0; round < N; ++round) {
@@ -202,7 +201,7 @@ static void test_musig2_key_coefficient_binding() {
 static void test_musig2_message_binding() {
     std::printf("[3] MuSig2: Different Messages -> Different Signatures\n");
 
-    std::mt19937_64 rng(0xF5650001);
+    std::mt19937_64 rng(0xF5650001);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int N = 20;
 
     for (int round = 0; round < N; ++round) {
@@ -274,7 +273,7 @@ static void test_musig2_message_binding() {
 static void test_musig2_nonce_binding() {
     std::printf("[4] MuSig2: Nonce Binding (fresh nonces -> different R)\n");
 
-    std::mt19937_64 rng(0xA0CEFACE);
+    std::mt19937_64 rng(0xA0CEFACE);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int N = 20;
 
     for (int round = 0; round < N; ++round) {
@@ -334,7 +333,7 @@ for (int i = 0; i < 2; ++i) {
 static void test_musig2_fault_injection() {
     std::printf("[5] MuSig2: Fault Injection (wrong key in partial sign)\n");
 
-    std::mt19937_64 rng(0xFA017000);
+    std::mt19937_64 rng(0xFA017000);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int N = 10;
 
     for (int round = 0; round < N; ++round) {
@@ -390,7 +389,7 @@ static void test_musig2_fault_injection() {
 static void test_frost_bad_share_dkg() {
     std::printf("[6] FROST: Malicious Participant -- Bad DKG Share\n");
 
-    std::mt19937_64 rng(0xBAD50A8E);
+    std::mt19937_64 rng(0xBAD50A8E);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int N = 10;
 
     for (int round = 0; round < N; ++round) {
@@ -430,7 +429,7 @@ for (uint32_t j = 0; j < n; ++j) {
 static void test_frost_bad_partial_sig() {
     std::printf("[7] FROST: Malicious Participant -- Bad Partial Sig\n");
 
-    std::mt19937_64 rng(0xBAD51600);
+    std::mt19937_64 rng(0xBAD51600);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int N = 10;
 
     for (int round = 0; round < N; ++round) {
@@ -501,7 +500,7 @@ for (uint32_t j = 0; j < n; ++j) ms.push_back(smatrix[j][i]);
 static void test_frost_message_binding() {
     std::printf("[8] FROST: Message Binding (different messages -> different sigs)\n");
 
-    std::mt19937_64 rng(0xF5B1D000);
+    std::mt19937_64 rng(0xF5B1D000);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     const int N = 10;
 
     for (int round = 0; round < N; ++round) {
@@ -562,7 +561,7 @@ for (uint32_t j = 0; j < n; ++j) ms.push_back(smatrix[j][i]);
 static void test_frost_signer_set_binding() {
     std::printf("[9] FROST: Signer Set Binding (same key, different subsets)\n");
 
-    std::mt19937_64 rng(0xF5557000);
+    std::mt19937_64 rng(0xF5557000);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
 
     // 2-of-3 DKG
     uint32_t t = 2, n = 3;

--- a/audit/unified_audit_runner.cpp
+++ b/audit/unified_audit_runner.cpp
@@ -311,15 +311,15 @@ static PlatformInfo detect_platform() {
     // -- Compiler --
 #if defined(__clang__)
     char buf[128];
-    std::snprintf(buf, sizeof(buf), "Clang %d.%d.%d", __clang_major__, __clang_minor__, __clang_patchlevel__);
+    (void)std::snprintf(buf, sizeof(buf), "Clang %d.%d.%d", __clang_major__, __clang_minor__, __clang_patchlevel__);
     info.compiler = buf;
 #elif defined(__GNUC__)
     char buf[128];
-    std::snprintf(buf, sizeof(buf), "GCC %d.%d.%d", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
+    (void)std::snprintf(buf, sizeof(buf), "GCC %d.%d.%d", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
     info.compiler = buf;
 #elif defined(_MSC_VER)
     char buf[128];
-    std::snprintf(buf, sizeof(buf), "MSVC %d", _MSC_VER);
+    (void)std::snprintf(buf, sizeof(buf), "MSVC %d", _MSC_VER);
     info.compiler = buf;
 #else
     info.compiler = "Unknown";
@@ -336,7 +336,7 @@ static PlatformInfo detect_platform() {
     auto now = std::chrono::system_clock::now();
     auto t = std::chrono::system_clock::to_time_t(now);
     char timebuf[64];
-    std::strftime(timebuf, sizeof(timebuf), "%Y-%m-%dT%H:%M:%S", std::localtime(&t));
+    (void)std::strftime(timebuf, sizeof(timebuf), "%Y-%m-%dT%H:%M:%S", std::localtime(&t));
     info.timestamp = timebuf;
 
     // -- Version / git / framework --
@@ -422,7 +422,7 @@ static void write_json_report(const char* path,
                                double total_ms) {
     FILE* f = std::fopen(path, "w");
     if (!f) {
-        std::fprintf(stderr, "WARNING: Cannot open %s for writing\n", path);
+        (void)std::fprintf(stderr, "WARNING: Cannot open %s for writing\n", path);
         return;
     }
 
@@ -434,66 +434,66 @@ static void write_json_report(const char* path,
 
     auto sections = compute_section_summaries(results);
 
-    std::fprintf(f, "{\n");
-    std::fprintf(f, "  \"report_type\": \"industrial_self_audit\",\n");
-    std::fprintf(f, "  \"library\": \"UltrafastSecp256k1\",\n");
-    std::fprintf(f, "  \"library_version\": \"%s\",\n", json_escape(plat.library_version).c_str());
-    std::fprintf(f, "  \"git_hash\": \"%s\",\n", json_escape(plat.git_hash).c_str());
-    std::fprintf(f, "  \"audit_framework_version\": \"%s\",\n", json_escape(plat.framework_version).c_str());
-    std::fprintf(f, "  \"timestamp\": \"%s\",\n", json_escape(plat.timestamp).c_str());
-    std::fprintf(f, "  \"platform\": {\n");
-    std::fprintf(f, "    \"os\": \"%s\",\n", json_escape(plat.os).c_str());
-    std::fprintf(f, "    \"arch\": \"%s\",\n", json_escape(plat.arch).c_str());
-    std::fprintf(f, "    \"compiler\": \"%s\",\n", json_escape(plat.compiler).c_str());
-    std::fprintf(f, "    \"build_type\": \"%s\"\n", json_escape(plat.build_type).c_str());
-    std::fprintf(f, "  },\n");
-    std::fprintf(f, "  \"summary\": {\n");
-    std::fprintf(f, "    \"total_modules\": %d,\n", (int)results.size() + 1);
-    std::fprintf(f, "    \"passed\": %d,\n", total_pass);
-    std::fprintf(f, "    \"failed\": %d,\n", total_fail);
-    std::fprintf(f, "    \"all_passed\": %s,\n", (total_fail == 0) ? "true" : "false");
-    std::fprintf(f, "    \"total_time_ms\": %.1f,\n", total_ms);
-    std::fprintf(f, "    \"audit_verdict\": \"%s\"\n",
+    (void)std::fprintf(f, "{\n");
+    (void)std::fprintf(f, "  \"report_type\": \"industrial_self_audit\",\n");
+    (void)std::fprintf(f, "  \"library\": \"UltrafastSecp256k1\",\n");
+    (void)std::fprintf(f, "  \"library_version\": \"%s\",\n", json_escape(plat.library_version).c_str());
+    (void)std::fprintf(f, "  \"git_hash\": \"%s\",\n", json_escape(plat.git_hash).c_str());
+    (void)std::fprintf(f, "  \"audit_framework_version\": \"%s\",\n", json_escape(plat.framework_version).c_str());
+    (void)std::fprintf(f, "  \"timestamp\": \"%s\",\n", json_escape(plat.timestamp).c_str());
+    (void)std::fprintf(f, "  \"platform\": {\n");
+    (void)std::fprintf(f, "    \"os\": \"%s\",\n", json_escape(plat.os).c_str());
+    (void)std::fprintf(f, "    \"arch\": \"%s\",\n", json_escape(plat.arch).c_str());
+    (void)std::fprintf(f, "    \"compiler\": \"%s\",\n", json_escape(plat.compiler).c_str());
+    (void)std::fprintf(f, "    \"build_type\": \"%s\"\n", json_escape(plat.build_type).c_str());
+    (void)std::fprintf(f, "  },\n");
+    (void)std::fprintf(f, "  \"summary\": {\n");
+    (void)std::fprintf(f, "    \"total_modules\": %d,\n", (int)results.size() + 1);
+    (void)std::fprintf(f, "    \"passed\": %d,\n", total_pass);
+    (void)std::fprintf(f, "    \"failed\": %d,\n", total_fail);
+    (void)std::fprintf(f, "    \"all_passed\": %s,\n", (total_fail == 0) ? "true" : "false");
+    (void)std::fprintf(f, "    \"total_time_ms\": %.1f,\n", total_ms);
+    (void)std::fprintf(f, "    \"audit_verdict\": \"%s\"\n",
                  (total_fail == 0) ? "AUDIT-READY" : "AUDIT-BLOCKED");
-    std::fprintf(f, "  },\n");
+    (void)std::fprintf(f, "  },\n");
 
     // Selftest
-    std::fprintf(f, "  \"selftest\": {\n");
-    std::fprintf(f, "    \"passed\": %s,\n", selftest_passed ? "true" : "false");
-    std::fprintf(f, "    \"time_ms\": %.1f\n", selftest_ms);
-    std::fprintf(f, "  },\n");
+    (void)std::fprintf(f, "  \"selftest\": {\n");
+    (void)std::fprintf(f, "    \"passed\": %s,\n", selftest_passed ? "true" : "false");
+    (void)std::fprintf(f, "    \"time_ms\": %.1f\n", selftest_ms);
+    (void)std::fprintf(f, "  },\n");
 
     // Sections summary
-    std::fprintf(f, "  \"sections\": [\n");
+    (void)std::fprintf(f, "  \"sections\": [\n");
     for (int s = 0; s < (int)sections.size(); ++s) {
         auto& sec = sections[s];
-        std::fprintf(f, "    {\n");
-        std::fprintf(f, "      \"id\": \"%s\",\n", sec.section_id);
-        std::fprintf(f, "      \"title\": \"%s\",\n", json_escape(sec.title_en).c_str());
-        std::fprintf(f, "      \"total\": %d,\n", sec.total);
-        std::fprintf(f, "      \"passed\": %d,\n", sec.passed);
-        std::fprintf(f, "      \"failed\": %d,\n", sec.failed);
-        std::fprintf(f, "      \"time_ms\": %.1f,\n", sec.time_ms);
-        std::fprintf(f, "      \"status\": \"%s\",\n", (sec.failed == 0) ? "PASS" : "FAIL");
+        (void)std::fprintf(f, "    {\n");
+        (void)std::fprintf(f, "      \"id\": \"%s\",\n", sec.section_id);
+        (void)std::fprintf(f, "      \"title\": \"%s\",\n", json_escape(sec.title_en).c_str());
+        (void)std::fprintf(f, "      \"total\": %d,\n", sec.total);
+        (void)std::fprintf(f, "      \"passed\": %d,\n", sec.passed);
+        (void)std::fprintf(f, "      \"failed\": %d,\n", sec.failed);
+        (void)std::fprintf(f, "      \"time_ms\": %.1f,\n", sec.time_ms);
+        (void)std::fprintf(f, "      \"status\": \"%s\",\n", (sec.failed == 0) ? "PASS" : "FAIL");
 
         // Nested modules for this section
-        std::fprintf(f, "      \"modules\": [\n");
+        (void)std::fprintf(f, "      \"modules\": [\n");
         bool first = true;
         for (auto& r : results) {
             if (std::strcmp(r.section, sec.section_id) != 0) continue;
-            if (!first) std::fprintf(f, ",\n");
+            if (!first) (void)std::fprintf(f, ",\n");
             first = false;
-            std::fprintf(f, "        { \"id\": \"%s\", \"name\": \"%s\", \"passed\": %s, \"time_ms\": %.1f }",
+            (void)std::fprintf(f, "        { \"id\": \"%s\", \"name\": \"%s\", \"passed\": %s, \"time_ms\": %.1f }",
                          r.id, json_escape(r.name).c_str(),
                          r.passed ? "true" : "false", r.elapsed_ms);
         }
-        std::fprintf(f, "\n      ]\n");
-        std::fprintf(f, "    }%s\n", (s + 1 < (int)sections.size()) ? "," : "");
+        (void)std::fprintf(f, "\n      ]\n");
+        (void)std::fprintf(f, "    }%s\n", (s + 1 < (int)sections.size()) ? "," : "");
     }
-    std::fprintf(f, "  ]\n");
-    std::fprintf(f, "}\n");
+    (void)std::fprintf(f, "  ]\n");
+    (void)std::fprintf(f, "}\n");
 
-    std::fclose(f);
+    (void)std::fclose(f);
 }
 
 // ============================================================================
@@ -507,7 +507,7 @@ static void write_text_report(const char* path,
                                double total_ms) {
     FILE* f = std::fopen(path, "w");
     if (!f) {
-        std::fprintf(stderr, "WARNING: Cannot open %s for writing\n", path);
+        (void)std::fprintf(stderr, "WARNING: Cannot open %s for writing\n", path);
         return;
     }
 
@@ -519,43 +519,43 @@ static void write_text_report(const char* path,
 
     auto sections = compute_section_summaries(results);
 
-    std::fprintf(f, "================================================================\n");
-    std::fprintf(f, "  UltrafastSecp256k1 -- Industrial Self-Audit Report\n");
-    std::fprintf(f, "================================================================\n\n");
-    std::fprintf(f, "Library:    UltrafastSecp256k1 v%s\n", plat.library_version.c_str());
-    std::fprintf(f, "Git Hash:   %s\n", plat.git_hash.c_str());
-    std::fprintf(f, "Framework:  Audit Framework v%s\n", plat.framework_version.c_str());
-    std::fprintf(f, "Timestamp:  %s\n", plat.timestamp.c_str());
-    std::fprintf(f, "OS:         %s\n", plat.os.c_str());
-    std::fprintf(f, "Arch:       %s\n", plat.arch.c_str());
-    std::fprintf(f, "Compiler:   %s\n", plat.compiler.c_str());
-    std::fprintf(f, "Build:      %s\n", plat.build_type.c_str());
-    std::fprintf(f, "\n");
+    (void)std::fprintf(f, "================================================================\n");
+    (void)std::fprintf(f, "  UltrafastSecp256k1 -- Industrial Self-Audit Report\n");
+    (void)std::fprintf(f, "================================================================\n\n");
+    (void)std::fprintf(f, "Library:    UltrafastSecp256k1 v%s\n", plat.library_version.c_str());
+    (void)std::fprintf(f, "Git Hash:   %s\n", plat.git_hash.c_str());
+    (void)std::fprintf(f, "Framework:  Audit Framework v%s\n", plat.framework_version.c_str());
+    (void)std::fprintf(f, "Timestamp:  %s\n", plat.timestamp.c_str());
+    (void)std::fprintf(f, "OS:         %s\n", plat.os.c_str());
+    (void)std::fprintf(f, "Arch:       %s\n", plat.arch.c_str());
+    (void)std::fprintf(f, "Compiler:   %s\n", plat.compiler.c_str());
+    (void)std::fprintf(f, "Build:      %s\n", plat.build_type.c_str());
+    (void)std::fprintf(f, "\n");
 
     // -- Library selftest ---
-    std::fprintf(f, "----------------------------------------------------------------\n");
-    std::fprintf(f, "  [0] Library Selftest (core KAT)          %s  (%.0f ms)\n",
+    (void)std::fprintf(f, "----------------------------------------------------------------\n");
+    (void)std::fprintf(f, "  [0] Library Selftest (core KAT)          %s  (%.0f ms)\n",
                  selftest_passed ? "PASS" : "FAIL", selftest_ms);
-    std::fprintf(f, "----------------------------------------------------------------\n\n");
+    (void)std::fprintf(f, "----------------------------------------------------------------\n\n");
 
     // -- 8 Sections ---
     int module_idx = 1;
     for (int s = 0; s < (int)sections.size(); ++s) {
         auto& sec = sections[s];
-        std::fprintf(f, "================================================================\n");
-        std::fprintf(f, "  Section %d/8: %s\n", s + 1, sec.title_en);
-        std::fprintf(f, "================================================================\n");
+        (void)std::fprintf(f, "================================================================\n");
+        (void)std::fprintf(f, "  Section %d/8: %s\n", s + 1, sec.title_en);
+        (void)std::fprintf(f, "================================================================\n");
 
         for (auto& r : results) {
             if (std::strcmp(r.section, sec.section_id) != 0) continue;
-            std::fprintf(f, "  [%2d] %-45s %s  (%.0f ms)\n",
+            (void)std::fprintf(f, "  [%2d] %-45s %s  (%.0f ms)\n",
                          module_idx++, r.name,
                          r.passed ? "PASS" : "FAIL", r.elapsed_ms);
         }
 
-        std::fprintf(f, "  -------- Section Result: %d/%d passed", sec.passed, sec.total);
-        if (sec.failed > 0) std::fprintf(f, " (%d FAILED)", sec.failed);
-        std::fprintf(f, " (%.0f ms)\n\n", sec.time_ms);
+        (void)std::fprintf(f, "  -------- Section Result: %d/%d passed", sec.passed, sec.total);
+        if (sec.failed > 0) (void)std::fprintf(f, " (%d FAILED)", sec.failed);
+        (void)std::fprintf(f, " (%.0f ms)\n\n", sec.time_ms);
     }
 
     // -- Grand total ---
@@ -643,7 +643,7 @@ int main(int argc, char* argv[]) {
             if (section_filter == SECTIONS[s].id) { found = true; break; }
         }
         if (!found) {
-            std::fprintf(stderr, "ERROR: unknown section '%s'\n", section_filter.c_str());
+            (void)std::fprintf(stderr, "ERROR: unknown section '%s'\n", section_filter.c_str());
             print_usage();
             return 1;
         }
@@ -735,7 +735,7 @@ int main(int argc, char* argv[]) {
         ++run_idx;
         if (!json_only) {
             std::printf("  [%2d/%d] %-45s ", run_idx, modules_to_run, m.name);
-            std::fflush(stdout);
+            (void)std::fflush(stdout);
         }
 
         auto t0 = std::chrono::steady_clock::now();

--- a/cpu/bench/bench_field_26.cpp
+++ b/cpu/bench/bench_field_26.cpp
@@ -17,6 +17,8 @@
 // because 10x26 needs only 32x32->64 multiplies (native on 32-bit).
 // ============================================================================
 
+// NOLINTBEGIN(clang-analyzer-core.StackAddressEscape) -- escape() is a benchmark idiom
+
 #include "secp256k1/field_26.hpp"
 #include "secp256k1/field.hpp"
 #include "secp256k1/selftest.hpp"
@@ -64,7 +66,7 @@ double bench_ns(Func&& f, int iterations) {
 // Intentionally leaks stack addresses into a volatile sink to defeat DCE.
 static volatile uint64_t sink;
 
-static void escape(const void* p) { // lgtm[cpp/stack-address-escape] // Intentional: benchmark anti-optimization
+static void escape(const void* p) {
     sink = reinterpret_cast<uintptr_t>(p);
 }
 
@@ -93,13 +95,13 @@ struct BenchResult {
 };
 
 static void print_header() {
-    std::printf("\n");
-    std::printf("===================================================================\n");
-    std::printf("  FieldElement (4x64) vs FieldElement26 (10x26) Benchmark\n");
-    std::printf("  Median of %d passes, %d warmup iterations\n", PASSES, WARMUP);
-    std::printf("===================================================================\n\n");
-    std::printf("%-36s %10s %10s %10s\n", "Operation", "4x64 (ns)", "10x26(ns)", "Ratio");
-    std::printf("%-36s %10s %10s %10s\n", "------------------------------------",
+    (void)std::printf("\n");
+    (void)std::printf("===================================================================\n");
+    (void)std::printf("  FieldElement (4x64) vs FieldElement26 (10x26) Benchmark\n");
+    (void)std::printf("  Median of %d passes, %d warmup iterations\n", PASSES, WARMUP);
+    (void)std::printf("===================================================================\n\n");
+    (void)std::printf("%-36s %10s %10s %10s\n", "Operation", "4x64 (ns)", "10x26(ns)", "Ratio");
+    (void)std::printf("%-36s %10s %10s %10s\n", "------------------------------------",
                 "----------", "----------", "----------");
 }
 
@@ -107,31 +109,31 @@ static void print_result(const BenchResult& r) {
     double const ratio = r.ns_4x64 / r.ns_10x26;
     const char* indicator = (ratio > 1.05) ? " <-- 10x26 wins" :
                             (ratio < 0.95) ? " <-- 4x64 wins" : "";
-    std::printf("%-36s %9.2f  %9.2f  %8.3fx%s\n",
+    (void)std::printf("%-36s %9.2f  %9.2f  %8.3fx%s\n",
                 r.name, r.ns_4x64, r.ns_10x26, ratio, indicator);
 }
 
 static void print_separator(const char* section) {
-    std::printf("\n--- %s ---\n", section);
+    (void)std::printf("\n--- %s ---\n", section);
 }
 
 // ===========================================================================
 // Old Reference Benchmarks (from docs/BENCHMARKS.md)
 // ===========================================================================
 static void print_reference_table() {
-    std::printf("\n");
-    std::printf("===================================================================\n");
-    std::printf("  Reference: Old Benchmark Data (docs/BENCHMARKS.md)\n");
-    std::printf("===================================================================\n");
-    std::printf("  Platform               Field Mul (ns)  Field Add (ns)\n");
-    std::printf("  ---------------------  --------------  --------------\n");
-    std::printf("  x86-64 (i7-13700K)           33              11\n");
-    std::printf("  ARM64  (RK3588)              85              18\n");
-    std::printf("  RISC-V 64 (D1)              198              34\n");
-    std::printf("  ESP32-S3 (LX7)            7,458             636\n");
-    std::printf("  ESP32-PICO (LX6)          6,993             985\n");
-    std::printf("  STM32F103 (CM3)          15,331           4,139\n");
-    std::printf("===================================================================\n\n");
+    (void)std::printf("\n");
+    (void)std::printf("===================================================================\n");
+    (void)std::printf("  Reference: Old Benchmark Data (docs/BENCHMARKS.md)\n");
+    (void)std::printf("===================================================================\n");
+    (void)std::printf("  Platform               Field Mul (ns)  Field Add (ns)\n");
+    (void)std::printf("  ---------------------  --------------  --------------\n");
+    (void)std::printf("  x86-64 (i7-13700K)           33              11\n");
+    (void)std::printf("  ARM64  (RK3588)              85              18\n");
+    (void)std::printf("  RISC-V 64 (D1)              198              34\n");
+    (void)std::printf("  ESP32-S3 (LX7)            7,458             636\n");
+    (void)std::printf("  ESP32-PICO (LX6)          6,993             985\n");
+    (void)std::printf("  STM32F103 (CM3)          15,331           4,139\n");
+    (void)std::printf("===================================================================\n\n");
 }
 
 // ===========================================================================
@@ -139,9 +141,9 @@ static void print_reference_table() {
 // ===========================================================================
 
 int main() {
-    std::printf("[bench_field_26] Running arithmetic validation...\n");
+    (void)std::printf("[bench_field_26] Running arithmetic validation...\n");
     secp256k1::fast::Selftest(false);
-    std::printf("[bench_field_26] Validation OK\n");
+    (void)std::printf("[bench_field_26] Validation OK\n");
 
     // Print reference from old benchmarks
     print_reference_table();
@@ -243,8 +245,8 @@ int main() {
             escape(&tmp);
         }, ITERS);
 
-        std::printf("%-36s %9s  %9.2f\n", "Normalize (weak, 10x26 only)", "N/A", ns26_weak);
-        std::printf("%-36s %9s  %9.2f\n", "Normalize (full, 10x26 only)", "N/A", ns26_full);
+        (void)std::printf("%-36s %9s  %9.2f\n", "Normalize (weak, 10x26 only)", "N/A", ns26_weak);
+        (void)std::printf("%-36s %9s  %9.2f\n", "Normalize (full, 10x26 only)", "N/A", ns26_full);
     }
 
     // -- 5. Negation ------------------------------------------------------
@@ -276,7 +278,7 @@ int main() {
             escape(&r26);
         }, ITERS);
 
-        std::printf("%-36s %9s  %9.2f\n", "Half (10x26 only)", "N/A", ns26);
+        (void)std::printf("%-36s %9s  %9.2f\n", "Half (10x26 only)", "N/A", ns26);
     }
 
     // -- 7. Conversion cost -----------------------------------------------
@@ -295,8 +297,8 @@ int main() {
             escape(&r4);
         }, ITERS);
 
-        std::printf("%-36s %9s  %9.2f\n", "Convert 4x64 -> 10x26", "N/A", ns_to26);
-        std::printf("%-36s %9.2f  %9s\n", "Convert 10x26 -> 4x64", ns_to4, "N/A");
+        (void)std::printf("%-36s %9s  %9.2f\n", "Convert 4x64 -> 10x26", "N/A", ns_to26);
+        (void)std::printf("%-36s %9.2f  %9s\n", "Convert 10x26 -> 4x64", ns_to4, "N/A");
     }
 
     // ======================================================================
@@ -327,7 +329,7 @@ int main() {
         }, ITERS);
 
         char name[64];
-        std::snprintf(name, sizeof(name), "Add chain (%d adds + norm)", chain_len);
+        (void)std::snprintf(name, sizeof(name), "Add chain (%d adds + norm)", chain_len);
         print_result({name, ns4, ns26});
     }
 
@@ -342,7 +344,7 @@ int main() {
 
         // 4x64 version
         double const ns4 = bench_ns([&]() {
-            FieldElement t0 = fe_a, t1 = fe_b;
+            FieldElement const t0 = fe_a, t1 = fe_b;
             FieldElement const u1 = t0 * t1;
             FieldElement const u2 = t1.square();
             FieldElement const s1 = u1 + u2;
@@ -360,7 +362,7 @@ int main() {
 
         // 10x26 version
         double const ns26 = bench_ns([&]() {
-            FieldElement26 t0 = fe26_a, t1 = fe26_b;
+            FieldElement26 const t0 = fe26_a, t1 = fe26_b;
             FieldElement26 const u1 = t0 * t1;
             FieldElement26 const u2 = t1.square();
             FieldElement26 const s1 = u1 + u2;          // lazy add
@@ -475,7 +477,7 @@ int main() {
         double const mul4_mops  = 1000.0 / mul4_ns;
         double const mul26_mops = 1000.0 / mul26_ns;
 
-        std::printf("%-36s %7.2f M/s  %7.2f M/s  %6.3fx\n",
+        (void)std::printf("%-36s %7.2f M/s  %7.2f M/s  %6.3fx\n",
                     "Multiplication throughput",
                     mul4_mops, mul26_mops, mul26_mops / mul4_mops);
 
@@ -493,7 +495,7 @@ int main() {
         double const add4_mops  = 1000.0 / add4_ns;
         double const add26_mops = 1000.0 / add26_ns;
 
-        std::printf("%-36s %7.2f M/s  %7.2f M/s  %6.3fx\n",
+        (void)std::printf("%-36s %7.2f M/s  %7.2f M/s  %6.3fx\n",
                     "Addition throughput",
                     add4_mops, add26_mops, add26_mops / add4_mops);
 
@@ -511,7 +513,7 @@ int main() {
         double const sqr4_mops  = 1000.0 / sqr4_ns;
         double const sqr26_mops = 1000.0 / sqr26_ns;
 
-        std::printf("%-36s %7.2f M/s  %7.2f M/s  %6.3fx\n",
+        (void)std::printf("%-36s %7.2f M/s  %7.2f M/s  %6.3fx\n",
                     "Squaring throughput",
                     sqr4_mops, sqr26_mops, sqr26_mops / sqr4_mops);
     }
@@ -519,19 +521,21 @@ int main() {
     // ======================================================================
     // Section 5: Platform Context
     // ======================================================================
-    std::printf("\n===================================================================\n");
-    std::printf("  Legend: Ratio = 4x64_time / 10x26_time  (>1 = 10x26 faster)\n");
-    std::printf("\n");
-    std::printf("  On x86-64:  4x64 uses native 64-bit ops -> 4x64 expected to win.\n");
-    std::printf("              10x26 loses here due to more limbs (10 vs 4).\n");
-    std::printf("\n");
-    std::printf("  On 32-bit:  10x26 uses only 32x32->64 multiplies (native).\n");
-    std::printf("              4x64 needs 64-bit math emulated as 4x calls.\n");
-    std::printf("              10x26 wins significantly on ESP32/STM32/ARM32.\n");
-    std::printf("\n");
-    std::printf("  Lazy-reduction advantage: add chains ALWAYS benefit regardless\n");
-    std::printf("  of platform, since 10x26 adds are 10 plain uint32 adds.\n");
-    std::printf("===================================================================\n\n");
+    (void)std::printf("\n===================================================================\n");
+    (void)std::printf("  Legend: Ratio = 4x64_time / 10x26_time  (>1 = 10x26 faster)\n");
+    (void)std::printf("\n");
+    (void)std::printf("  On x86-64:  4x64 uses native 64-bit ops -> 4x64 expected to win.\n");
+    (void)std::printf("              10x26 loses here due to more limbs (10 vs 4).\n");
+    (void)std::printf("\n");
+    (void)std::printf("  On 32-bit:  10x26 uses only 32x32->64 multiplies (native).\n");
+    (void)std::printf("              4x64 needs 64-bit math emulated as 4x calls.\n");
+    (void)std::printf("              10x26 wins significantly on ESP32/STM32/ARM32.\n");
+    (void)std::printf("\n");
+    (void)std::printf("  Lazy-reduction advantage: add chains ALWAYS benefit regardless\n");
+    (void)std::printf("  of platform, since 10x26 adds are 10 plain uint32 adds.\n");
+    (void)std::printf("===================================================================\n\n");
 
     return 0;
 }
+
+// NOLINTEND(clang-analyzer-core.StackAddressEscape)

--- a/cpu/bench/bench_field_52.cpp
+++ b/cpu/bench/bench_field_52.cpp
@@ -48,13 +48,13 @@ struct BenchResult {
 };
 
 static void print_header() {
-    std::printf("\n");
-    std::printf("=================================================================\n");
-    std::printf("  FieldElement (4x64) vs FieldElement52 (5x52) Benchmark\n");
-    std::printf("=================================================================\n");
+    (void)std::printf("\n");
+    (void)std::printf("=================================================================\n");
+    (void)std::printf("  FieldElement (4x64) vs FieldElement52 (5x52) Benchmark\n");
+    (void)std::printf("=================================================================\n");
     H.print_config();
-    std::printf("\n%-36s %10s %10s %10s\n", "Operation", "4x64 (ns)", "5x52 (ns)", "Ratio");
-    std::printf("%-36s %10s %10s %10s\n", "------------------------------------",
+    (void)std::printf("\n%-36s %10s %10s %10s\n", "Operation", "4x64 (ns)", "5x52 (ns)", "Ratio");
+    (void)std::printf("%-36s %10s %10s %10s\n", "------------------------------------",
                 "----------", "----------", "----------");
 }
 
@@ -62,12 +62,12 @@ static void print_result(const BenchResult& r) {
     double const ratio = r.ns_4x64 / r.ns_5x52;
     const char* indicator = (ratio > 1.05) ? " <-- 5x52 wins" :
                             (ratio < 0.95) ? " <-- 4x64 wins" : "";
-    std::printf("%-36s %9.2f  %9.2f  %8.3fx%s\n",
+    (void)std::printf("%-36s %9.2f  %9.2f  %8.3fx%s\n",
                 r.name, r.ns_4x64, r.ns_5x52, ratio, indicator);
 }
 
 static void print_separator(const char* section) {
-    std::printf("\n--- %s ---\n", section);
+    (void)std::printf("\n--- %s ---\n", section);
 }
 
 // =============================================================================
@@ -75,9 +75,9 @@ static void print_separator(const char* section) {
 // =============================================================================
 
 int main() {
-    std::printf("[bench_field_52] Running arithmetic validation...\n");
+    (void)std::printf("[bench_field_52] Running arithmetic validation...\n");
     secp256k1::fast::Selftest(false);
-    std::printf("[bench_field_52] Validation OK\n");
+    (void)std::printf("[bench_field_52] Validation OK\n");
 
     bench::pin_thread_and_elevate();
 
@@ -167,8 +167,8 @@ int main() {
             bench::DoNotOptimize(tmp);
         });
 
-        std::printf("%-36s %9s  %9.2f\n", "Normalize (weak, 5x52 only)", "N/A", ns5_weak);
-        std::printf("%-36s %9s  %9.2f\n", "Normalize (full, 5x52 only)", "N/A", ns5_full);
+        (void)std::printf("%-36s %9s  %9.2f\n", "Normalize (weak, 5x52 only)", "N/A", ns5_weak);
+        (void)std::printf("%-36s %9s  %9.2f\n", "Normalize (full, 5x52 only)", "N/A", ns5_full);
     }
 
     // -- 5. Negation ----------------------------------------------------------
@@ -200,7 +200,7 @@ int main() {
             bench::DoNotOptimize(r5);
         });
 
-        std::printf("%-36s %9s  %9.2f\n", "Half (5x52 only)", "N/A", ns5);
+        (void)std::printf("%-36s %9s  %9.2f\n", "Half (5x52 only)", "N/A", ns5);
     }
 
     // -- 7. Conversion cost ---------------------------------------------------
@@ -219,8 +219,8 @@ int main() {
             bench::DoNotOptimize(r4);
         });
 
-        std::printf("%-36s %9s  %9.2f\n", "Convert 4x64 -> 5x52", "N/A", ns_to52);
-        std::printf("%-36s %9.2f  %9s\n", "Convert 5x52 -> 4x64", ns_to4, "N/A");
+        (void)std::printf("%-36s %9s  %9.2f\n", "Convert 4x64 -> 5x52", "N/A", ns_to52);
+        (void)std::printf("%-36s %9.2f  %9s\n", "Convert 5x52 -> 4x64", ns_to4, "N/A");
     }
 
     // =========================================================================
@@ -253,7 +253,7 @@ int main() {
         });
 
         char name[64];
-        std::snprintf(name, sizeof(name), "Add chain (%d adds + norm)", chain_len);
+        (void)std::snprintf(name, sizeof(name), "Add chain (%d adds + norm)", chain_len);
         print_result({name, ns4, ns5});
     }
 
@@ -267,7 +267,7 @@ int main() {
 
         // 4x64 version
         double const ns4 = H.run(ITERS, [&]() {
-            FieldElement t0 = fe_a, t1 = fe_b;
+            FieldElement const t0 = fe_a, t1 = fe_b;
             // Simulate point-add field ops
             FieldElement const u1 = t0 * t1;
             FieldElement const u2 = t1.square();
@@ -286,7 +286,7 @@ int main() {
 
         // 5x52 version
         double const ns5 = H.run(ITERS, [&]() {
-            FieldElement52 t0 = fe52_a, t1 = fe52_b;
+            FieldElement52 const t0 = fe52_a, t1 = fe52_b;
             FieldElement52 const u1 = t0 * t1;
             FieldElement52 const u2 = t1.square();
             FieldElement52 const s1 = u1 + u2;          // lazy add
@@ -402,7 +402,7 @@ int main() {
         double const mul4_mops = 1000.0 / mul4_ns;
         double const mul5_mops = 1000.0 / mul5_ns;
 
-        std::printf("%-36s %7.2f M/s  %7.2f M/s  %6.3fx\n",
+        (void)std::printf("%-36s %7.2f M/s  %7.2f M/s  %6.3fx\n",
                     "Multiplication throughput",
                     mul4_mops, mul5_mops, mul5_mops / mul4_mops);
 
@@ -420,7 +420,7 @@ int main() {
         double const add4_mops = 1000.0 / add4_ns;
         double const add5_mops = 1000.0 / add5_ns;
 
-        std::printf("%-36s %7.2f M/s  %7.2f M/s  %6.3fx\n",
+        (void)std::printf("%-36s %7.2f M/s  %7.2f M/s  %6.3fx\n",
                     "Addition throughput",
                     add4_mops, add5_mops, add5_mops / add4_mops);
 
@@ -438,16 +438,16 @@ int main() {
         double const sqr4_mops = 1000.0 / sqr4_ns;
         double const sqr5_mops = 1000.0 / sqr5_ns;
 
-        std::printf("%-36s %7.2f M/s  %7.2f M/s  %6.3fx\n",
+        (void)std::printf("%-36s %7.2f M/s  %7.2f M/s  %6.3fx\n",
                     "Squaring throughput",
                     sqr4_mops, sqr5_mops, sqr5_mops / sqr4_mops);
     }
 
-    std::printf("\n=================================================================\n");
-    std::printf("  Legend: Ratio = 4x64_time / 5x52_time  (>1 = 5x52 faster)\n");
-    std::printf("  5x52 advantage: add chains (lazy), fewer carries\n");
-    std::printf("  4x64 advantage: fewer limbs for mul (4 vs 5), no conversion\n");
-    std::printf("=================================================================\n\n");
+    (void)std::printf("\n=================================================================\n");
+    (void)std::printf("  Legend: Ratio = 4x64_time / 5x52_time  (>1 = 5x52 faster)\n");
+    (void)std::printf("  5x52 advantage: add chains (lazy), fewer carries\n");
+    (void)std::printf("  4x64 advantage: fewer limbs for mul (4 vs 5), no conversion\n");
+    (void)std::printf("=================================================================\n\n");
 
     return 0;
 }

--- a/cpu/bench/bench_field_mul_kernels.cpp
+++ b/cpu/bench/bench_field_mul_kernels.cpp
@@ -57,7 +57,7 @@ int main() {
 #endif
 
     // Prepare random inputs
-    std::mt19937_64 rng(123456789ULL);
+    std::mt19937_64 rng(123456789ULL);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     std::uniform_int_distribution<uint64_t> dist;
     std::vector<Pair> vec(elements);
     for (auto& p : vec) {

--- a/cpu/bench/bench_jsf_vs_shamir.cpp
+++ b/cpu/bench/bench_jsf_vs_shamir.cpp
@@ -13,7 +13,7 @@ using namespace secp256k1::fast;
 
 static std::vector<Scalar> gen_scalars(size_t count) {
     std::vector<Scalar> out; out.reserve(count);
-    std::mt19937_64 rng(0xC0FFEEULL);
+    std::mt19937_64 rng(0xC0FFEEULL);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     for (size_t i = 0; i < count; ++i) {
         std::array<std::uint8_t, 32> b{};
         for (size_t j = 0; j < 4; ++j) {

--- a/cpu/include/secp256k1/benchmark_harness.hpp
+++ b/cpu/include/secp256k1/benchmark_harness.hpp
@@ -352,7 +352,7 @@ public:
     template <typename Func>
     double run_and_print(const char* name, int iters, Func&& func) const {
         Stats st = run_stats(iters, func);
-        std::printf("  %-28s %9.2f ns  (min=%6.2f  median=%6.2f  stddev=%5.2f  n=%d-%d)\n",
+        (void)std::printf("  %-28s %9.2f ns  (min=%6.2f  median=%6.2f  stddev=%5.2f  n=%d-%d)\n",
                     name, st.median_ns, st.min_ns, st.median_ns, st.stddev_ns,
                     st.samples, st.outliers);
         return st.median_ns;
@@ -360,9 +360,9 @@ public:
 
     // Print harness configuration info
     void print_config() const {
-        std::printf("  Timer:    %s\n", Timer::timer_name());
-        std::printf("  Warmup:   %d iterations\n", warmup_iters);
-        std::printf("  Passes:   %zu (IQR outlier removal + median)\n", passes);
+        (void)std::printf("  Timer:    %s\n", Timer::timer_name());
+        (void)std::printf("  Warmup:   %d iterations\n", warmup_iters);
+        (void)std::printf("  Passes:   %zu (IQR outlier removal + median)\n", passes);
     }
 };
 
@@ -370,11 +370,11 @@ public:
 
 inline const char* format_ns(double ns, char* buf, std::size_t buflen) {
     if (ns < 1000.0) {
-        std::snprintf(buf, buflen, "%.2f ns", ns);
+        (void)std::snprintf(buf, buflen, "%.2f ns", ns);
     } else if (ns < 1000000.0) {
-        std::snprintf(buf, buflen, "%.2f us", ns / 1000.0);
+        (void)std::snprintf(buf, buflen, "%.2f us", ns / 1000.0);
     } else {
-        std::snprintf(buf, buflen, "%.2f ms", ns / 1000000.0);
+        (void)std::snprintf(buf, buflen, "%.2f ms", ns / 1000000.0);
     }
     return buf;
 }

--- a/cpu/include/secp256k1/context.hpp
+++ b/cpu/include/secp256k1/context.hpp
@@ -103,7 +103,8 @@ private:
     static void set_name(CurveContext& ctx, const char* label) {
         std::memset(ctx.name, 0, sizeof(ctx.name));
         std::size_t len = 0;
-        while (len < sizeof(ctx.name) - 1 && label[len]) { // lgtm[cpp/offset-use-before-range-check]
+        // cppcheck-suppress arrayIndexOutOfBoundsCond  ; len is bounded by sizeof(ctx.name)-1
+        while (len < sizeof(ctx.name) - 1 && label[len]) {
             ctx.name[len] = label[len];
             ++len;
         }

--- a/cpu/include/secp256k1/debug_invariants.hpp
+++ b/cpu/include/secp256k1/debug_invariants.hpp
@@ -151,7 +151,7 @@ struct DebugCounters {
     uint64_t invariant_check_count = 0;
     
     void report() const noexcept {
-        std::fprintf(stderr,
+        (void)std::fprintf(stderr,
             "[DEBUG COUNTERS]\n"
             "  field_mul:   %llu\n"
             "  field_sqr:   %llu\n"
@@ -179,7 +179,7 @@ inline DebugCounters& counters() noexcept {
 
 #define SECP_ASSERT(expr) do { \
     if (!(expr)) { \
-        std::fprintf(stderr, \
+        (void)std::fprintf(stderr, \
             "SECP_ASSERT FAILED: %s\n  at %s:%d (%s)\n", \
             #expr, __FILE__, __LINE__, __func__); \
         std::abort(); \
@@ -188,7 +188,7 @@ inline DebugCounters& counters() noexcept {
 
 #define SECP_ASSERT_MSG(expr, msg) do { \
     if (!(expr)) { \
-        std::fprintf(stderr, \
+        (void)std::fprintf(stderr, \
             "SECP_ASSERT FAILED: %s\n  %s\n  at %s:%d (%s)\n", \
             #expr, msg, __FILE__, __LINE__, __func__); \
         std::abort(); \
@@ -198,11 +198,11 @@ inline DebugCounters& counters() noexcept {
 #define SECP_ASSERT_NORMALIZED(fe) do { \
     ++secp256k1::fast::debug::counters().invariant_check_count; \
     if (!secp256k1::fast::debug::is_normalized_field_element(fe)) { \
-        std::fprintf(stderr, \
+        (void)std::fprintf(stderr, \
             "SECP_ASSERT_NORMALIZED FAILED: field element not canonical\n" \
             "  at %s:%d (%s)\n", __FILE__, __LINE__, __func__); \
         const auto& _l = (fe).limbs(); \
-        std::fprintf(stderr, "  limbs: [%016llx, %016llx, %016llx, %016llx]\n", \
+        (void)std::fprintf(stderr, "  limbs: [%016llx, %016llx, %016llx, %016llx]\n", \
             (unsigned long long)_l[0], (unsigned long long)_l[1], \
             (unsigned long long)_l[2], (unsigned long long)_l[3]); \
         std::abort(); \
@@ -212,7 +212,7 @@ inline DebugCounters& counters() noexcept {
 #define SECP_ASSERT_ON_CURVE(pt) do { \
     ++secp256k1::fast::debug::counters().invariant_check_count; \
     if (!secp256k1::fast::debug::is_on_curve(pt)) { \
-        std::fprintf(stderr, \
+        (void)std::fprintf(stderr, \
             "SECP_ASSERT_ON_CURVE FAILED: point not on secp256k1\n" \
             "  at %s:%d (%s)\n", __FILE__, __LINE__, __func__); \
         std::abort(); \
@@ -222,7 +222,7 @@ inline DebugCounters& counters() noexcept {
 #define SECP_ASSERT_SCALAR_VALID(s) do { \
     ++secp256k1::fast::debug::counters().invariant_check_count; \
     if (!secp256k1::fast::debug::is_valid_scalar(s)) { \
-        std::fprintf(stderr, \
+        (void)std::fprintf(stderr, \
             "SECP_ASSERT_SCALAR_VALID FAILED: scalar is zero\n" \
             "  at %s:%d (%s)\n", __FILE__, __LINE__, __func__); \
         std::abort(); \
@@ -233,7 +233,7 @@ inline DebugCounters& counters() noexcept {
 
 #define SECP_ASSERT_NOT_INFINITY(pt) do { \
     if ((pt).is_infinity()) { \
-        std::fprintf(stderr, \
+        (void)std::fprintf(stderr, \
             "SECP_ASSERT_NOT_INFINITY FAILED\n" \
             "  at %s:%d (%s)\n", __FILE__, __LINE__, __func__); \
         std::abort(); \

--- a/cpu/include/secp256k1/field.hpp
+++ b/cpu/include/secp256k1/field.hpp
@@ -239,7 +239,7 @@ FieldElement pow_p_minus_2_lehmer(FieldElement base);
 FieldElement pow_p_minus_2_stein(FieldElement base);
 FieldElement pow_p_minus_2_secp256k1_special(FieldElement base);
 FieldElement pow_p_minus_2_warp_optimized(FieldElement base);
-FieldElement pow_p_minus_2_double_base(FieldElement base);
+FieldElement pow_p_minus_2_double_base(const FieldElement& base);
 FieldElement pow_p_minus_2_compact_table(FieldElement base);
 
 // Wrapper functions

--- a/cpu/include/secp256k1/sha512.hpp
+++ b/cpu/include/secp256k1/sha512.hpp
@@ -67,11 +67,13 @@ public:
     digest_type finalize() noexcept {
         std::uint64_t const bit_len = total_ * 8;
         auto pad = static_cast<std::uint8_t>(0x80);
+        // cppcheck-suppress objectIndex
         update(&pad, 1);
 
         // Pad to 112 mod 128
         while (buf_len_ != 112) {
             std::uint8_t zero = 0;
+            // cppcheck-suppress objectIndex
             update(&zero, 1);
         }
 

--- a/cpu/src/address.cpp
+++ b/cpu/src/address.cpp
@@ -29,7 +29,7 @@ public:
         return ctx.finalize();
     }
 
-    RIPEMD160() {
+    RIPEMD160() : buf_{} {
         h_[0] = 0x67452301u; h_[1] = 0xEFCDAB89u;
         h_[2] = 0x98BADCFEu; h_[3] = 0x10325476u;
         h_[4] = 0xC3D2E1F0u;
@@ -78,8 +78,9 @@ private:
     void compress(const std::uint8_t* block) {
         std::uint32_t X[16];
         for (int i = 0; i < 16; ++i) {
-            X[i] = std::uint32_t(block[i*4]) | (std::uint32_t(block[i*4+1])<<8) |
-                   (std::uint32_t(block[i*4+2])<<16) | (std::uint32_t(block[i*4+3])<<24);
+            auto const idx = static_cast<std::size_t>(i) * 4;
+            X[i] = std::uint32_t(block[idx]) | (std::uint32_t(block[idx+1])<<8) |
+                   (std::uint32_t(block[idx+2])<<16) | (std::uint32_t(block[idx+3])<<24);
 }
 
         static constexpr int rl[80] = {
@@ -386,7 +387,7 @@ Bech32DecodeResult bech32_decode(const std::string& addr) {
     values.insert(values.end(), data5.begin(), data5.end());
     std::uint32_t const polymod = bech32_polymod(values);
 
-    Bech32Encoding enc;
+    Bech32Encoding enc = Bech32Encoding::BECH32;  // initialized to satisfy cppcoreguidelines
     if (polymod == 1) { enc = Bech32Encoding::BECH32;
     } else if (polymod == 0x2bc830a3u) { enc = Bech32Encoding::BECH32M;
     } else { return result;

--- a/cpu/src/bip32.cpp
+++ b/cpu/src/bip32.cpp
@@ -12,7 +12,6 @@ namespace secp256k1 {
 
 using fast::Scalar;
 using fast::Point;
-using fast::FieldElement;
 
 // -- HMAC-SHA512 --------------------------------------------------------------
 
@@ -65,7 +64,7 @@ private:
     uint8_t buf_[64];
     size_t buf_len_;
 
-    RIPEMD160() {
+    RIPEMD160() : buf_{} {
         h_[0] = 0x67452301u; h_[1] = 0xEFCDAB89u;
         h_[2] = 0x98BADCFEu; h_[3] = 0x10325476u;
         h_[4] = 0xC3D2E1F0u;
@@ -184,10 +183,11 @@ private:
 
         uint32_t X[16];
         for (int i = 0; i < 16; ++i) {
-            X[i] = static_cast<uint32_t>(block[i * 4]) |
-                   (static_cast<uint32_t>(block[i * 4 + 1]) << 8) |
-                   (static_cast<uint32_t>(block[i * 4 + 2]) << 16) |
-                   (static_cast<uint32_t>(block[i * 4 + 3]) << 24);
+            auto const idx = static_cast<std::size_t>(i) * 4;
+            X[i] = static_cast<uint32_t>(block[idx]) |
+                   (static_cast<uint32_t>(block[idx + 1]) << 8) |
+                   (static_cast<uint32_t>(block[idx + 2]) << 16) |
+                   (static_cast<uint32_t>(block[idx + 3]) << 24);
         }
 
         uint32_t al = h_[0], bl = h_[1], cl = h_[2], dl = h_[3], el = h_[4];

--- a/cpu/src/ct_point.cpp
+++ b/cpu/src/ct_point.cpp
@@ -1055,7 +1055,7 @@ static Scalar ct_scalar_mul_mod_n(const Scalar& a, const Scalar& b) noexcept {
 
     // --- Phase 1: reduce 512 -> 385 bits ---
     // m[0..6] = l[0..3] + l[4..7] * NC  (NC = {NC0, NC1, 1, 0})
-    std::uint64_t n0 = l[4], n1 = l[5], n2 = l[6], n3 = l[7];
+    std::uint64_t const n0 = l[4], n1 = l[5], n2 = l[6], n3 = l[7];
     unsigned __int128 c = 0;
 
     c = (unsigned __int128)n0 * NC0 + l[0];
@@ -2294,7 +2294,7 @@ static Scalar ct_scalar_mul_mod_n(const Scalar& a, const Scalar& b) noexcept {
 
     // --- Phase 1: reduce 512 -> 385 bits ---
     // m[0..6] = l[0..3] + l[4..7] * NC  (NC = {NC0, NC1, 1, 0})
-    std::uint64_t n0 = l[4], n1 = l[5], n2 = l[6], n3 = l[7];
+    std::uint64_t const n0 = l[4], n1 = l[5], n2 = l[6], n3 = l[7];
     std::uint64_t m0, m1, m2, m3, m4, m5;
     std::uint32_t m6;
     {

--- a/cpu/src/ct_sign.cpp
+++ b/cpu/src/ct_sign.cpp
@@ -15,9 +15,6 @@
 
 namespace secp256k1::ct {
 
-using fast::Scalar;
-using fast::Point;
-using fast::FieldElement;
 
 // ============================================================================
 // CT ECDSA Sign

--- a/cpu/src/ecdsa.cpp
+++ b/cpu/src/ecdsa.cpp
@@ -9,7 +9,6 @@ namespace secp256k1 {
 
 using fast::Scalar;
 using fast::Point;
-using fast::FieldElement;
 
 // -- Half-order for low-S check -----------------------------------------------
 // n/2 = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0

--- a/cpu/src/field.cpp
+++ b/cpu/src/field.cpp
@@ -2205,7 +2205,7 @@ FieldElement pow_p_minus_2_binary(FieldElement base) {
 }
 
 // Double-base chain (uses base and base^2 simultaneously)
-[[nodiscard]] FieldElement pow_p_minus_2_double_base(FieldElement base) {
+[[nodiscard]] FieldElement pow_p_minus_2_double_base(const FieldElement& base) {
     FieldElement const base2 = base.square();
     FieldElement result = FieldElement::one();
     
@@ -2768,7 +2768,9 @@ static const uint8_t inv256[128] = {
     int32_t di = 0, ei = 0, md = 0, me = 0, sd = 0, se = 0;
     int64_t cd = 0, ce = 0;
 
+    // cppcheck-suppress shiftTooManyBitsSigned
     sd = d.v[8] >> 31;
+    // cppcheck-suppress shiftTooManyBitsSigned
     se = e.v[8] >> 31;
     md = (u & sd) + (v & se);
     me = (q & sd) + (r & se);
@@ -2828,6 +2830,7 @@ static const uint8_t inv256[128] = {
             r5=r.v[5], r6=r.v[6], r7=r.v[7], r8=r.v[8];
     int32_t cond_add = 0, cond_negate = 0;
 
+    // cppcheck-suppress shiftTooManyBitsSigned
     cond_add = r8 >> 31;
     r0 += mod.modulus.v[0] & cond_add;
     r1 += mod.modulus.v[1] & cond_add;
@@ -2838,6 +2841,7 @@ static const uint8_t inv256[128] = {
     r6 += mod.modulus.v[6] & cond_add;
     r7 += mod.modulus.v[7] & cond_add;
     r8 += mod.modulus.v[8] & cond_add;
+    // cppcheck-suppress shiftTooManyBitsSigned
     cond_negate = sign >> 31;
     r0 = (r0 ^ cond_negate) - cond_negate;
     r1 = (r1 ^ cond_negate) - cond_negate;
@@ -2857,6 +2861,7 @@ static const uint8_t inv256[128] = {
     r7 += r6 >> 30; r6 &= M30;
     r8 += r7 >> 30; r7 &= M30;
 
+    // cppcheck-suppress shiftTooManyBitsSigned
     cond_add = r8 >> 31;
     r0 += mod.modulus.v[0] & cond_add;
     r1 += mod.modulus.v[1] & cond_add;
@@ -2937,8 +2942,11 @@ static const uint8_t inv256[128] = {
         }
 
         int32_t fn = f.v[len - 1], gn = g.v[len - 1];
+        // cppcheck-suppress shiftTooManyBitsSigned
         int32_t cond = ((int32_t)len - 2) >> 31;
+        // cppcheck-suppress shiftTooManyBitsSigned
         cond |= fn ^ (fn >> 31);
+        // cppcheck-suppress shiftTooManyBitsSigned
         cond |= gn ^ (gn >> 31);
         if (cond == 0) {
             f.v[len - 2] |= (uint32_t)fn << 30;

--- a/cpu/src/field_asm.cpp
+++ b/cpu/src/field_asm.cpp
@@ -360,17 +360,21 @@ void square_4_karatsuba(const uint64_t a[4], uint64_t result[8]) {
     
     // Subtract low_sq
     borrow = 0;
+    (void)borrow;
     borrow = subborrow64(borrow, sum_sq[0], low_sq[0], middle[0]);
     borrow = subborrow64(borrow, sum_sq[1], low_sq[1], middle[1]);
     borrow = subborrow64(borrow, sum_sq[2], low_sq[2], middle[2]);
     borrow = subborrow64(borrow, sum_sq[3], low_sq[3], middle[3]);
+    (void)borrow;
     
     // Subtract high_sq
     borrow = 0;
+    (void)borrow;
     borrow = subborrow64(borrow, middle[0], high_sq[0], middle[0]);
     borrow = subborrow64(borrow, middle[1], high_sq[1], middle[1]);
     borrow = subborrow64(borrow, middle[2], high_sq[2], middle[2]);
     borrow = subborrow64(borrow, middle[3], high_sq[3], middle[3]);
+    (void)borrow;
     
     // Step 5: Combine: result = low_sq + middle*2^128 + high_sq*2^256
     // Initialize result array
@@ -573,6 +577,7 @@ void montgomery_reduce_bmi2(uint64_t result[8]) {
         uint8_t carry = 0;
         carry = adcx64(reduced[i], lo, carry, reduced[i]);
         carry = adcx64(reduced[i + 1], hi, carry, reduced[i + 1]);
+        (void)carry;
         if (i + 2 < 5) {
             carry = adcx64(reduced[i + 2], 0, carry, reduced[i + 2]);
             if (i + 3 < 5) {
@@ -582,6 +587,7 @@ void montgomery_reduce_bmi2(uint64_t result[8]) {
                 }
             }
         }
+        (void)carry;
         
         // Add hi_limb * 2^32 (shift left by 32 bits)
         // This means: add (hi_limb << 32) at position i
@@ -591,6 +597,7 @@ void montgomery_reduce_bmi2(uint64_t result[8]) {
         
         carry = 0;
         carry = adcx64(reduced[i], lo_half, carry, reduced[i]);
+        (void)carry;
         carry = adcx64(reduced[i + 1], hi_half, carry, reduced[i + 1]);
         if (i + 2 < 5) {
             carry = adcx64(reduced[i + 2], 0, carry, reduced[i + 2]);
@@ -601,6 +608,7 @@ void montgomery_reduce_bmi2(uint64_t result[8]) {
                 }
             }
         }
+        (void)carry;
     }
     
     // If extra limb is non-zero, do one more reduction step
@@ -613,22 +621,26 @@ void montgomery_reduce_bmi2(uint64_t result[8]) {
         mulx64(hi_limb, 977, lo, hi);
         
         uint8_t carry = 0;
+        (void)carry;
         carry = adcx64(reduced[0], lo, carry, reduced[0]);
         carry = adcx64(reduced[1], hi, carry, reduced[1]);
         carry = adcx64(reduced[2], 0, carry, reduced[2]);
         carry = adcx64(reduced[3], 0, carry, reduced[3]);
         carry = adcx64(reduced[4], 0, carry, reduced[4]);
+        (void)carry;
         
         // Add hi_limb * 2^32
         uint64_t const lo_half = (hi_limb << 32);
         uint64_t const hi_half = hi_limb >> 32;
         
         carry = 0;
+        (void)carry;
         carry = adcx64(reduced[0], lo_half, carry, reduced[0]);
         carry = adcx64(reduced[1], hi_half, carry, reduced[1]);
         carry = adcx64(reduced[2], 0, carry, reduced[2]);
         carry = adcx64(reduced[3], 0, carry, reduced[3]);
         carry = adcx64(reduced[4], 0, carry, reduced[4]);
+        (void)carry;
     }
     
     // Final reduction: subtract p if result >= p

--- a/cpu/src/glv.cpp
+++ b/cpu/src/glv.cpp
@@ -42,8 +42,8 @@ static void glv_mul_comba(const std::uint32_t a[8], const std::uint32_t b[8],
 // Convert uint64_t[4] LE limbs to uint32_t[8] LE limbs
 static void limbs64_to_32(const std::uint64_t* src, std::uint32_t* dst) {
     for (int i = 0; i < 4; i++) {
-        dst[2 * i]     = (std::uint32_t)src[i];
-        dst[2 * i + 1] = (std::uint32_t)(src[i] >> 32);
+        dst[static_cast<std::size_t>(i) * 2]     = (std::uint32_t)src[i];
+        dst[static_cast<std::size_t>(i) * 2 + 1] = (std::uint32_t)(src[i] >> 32);
     }
 }
 

--- a/cpu/src/hash_accel.cpp
+++ b/cpu/src/hash_accel.cpp
@@ -214,7 +214,7 @@ void sha256_compress(const std::uint8_t block[64], std::uint32_t state[8]) noexc
 
     // Load message words (big-endian)
     for (int i = 0; i < 16; ++i) {
-        w[i] = load_be32(block + i * 4);
+        w[i] = load_be32(block + static_cast<std::size_t>(i) * 4);
     }
 
     // Message schedule expansion
@@ -263,7 +263,7 @@ void sha256_33(const std::uint8_t* pubkey33, std::uint8_t* out32) noexcept {
 
     // Store big-endian
     for (int i = 0; i < 8; ++i) {
-        store_be32(out32 + i * 4, state[i]);
+        store_be32(out32 + static_cast<std::size_t>(i) * 4, state[i]);
     }
 }
 
@@ -282,7 +282,7 @@ void sha256_32(const std::uint8_t* in32, std::uint8_t* out32) noexcept {
     sha256_compress(block, state);
 
     for (int i = 0; i < 8; ++i) {
-        store_be32(out32 + i * 4, state[i]);
+        store_be32(out32 + static_cast<std::size_t>(i) * 4, state[i]);
     }
 }
 
@@ -300,7 +300,7 @@ static inline std::uint32_t rmd_f(int j, std::uint32_t x, std::uint32_t y, std::
 void ripemd160_compress(const std::uint8_t block[64], std::uint32_t state[5]) noexcept {
     std::uint32_t X[16];
     for (int i = 0; i < 16; ++i) {
-        X[i] = load_le32(block + i * 4);
+        X[i] = load_le32(block + static_cast<std::size_t>(i) * 4);
 }
 
     static constexpr int rl[80] = {
@@ -373,7 +373,7 @@ void ripemd160_32(const std::uint8_t* in32, std::uint8_t* out20) noexcept {
 
     // Store little-endian
     for (int i = 0; i < 5; ++i) {
-        store_le32(out20 + i * 4, state[i]);
+        store_le32(out20 + static_cast<std::size_t>(i) * 4, state[i]);
     }
 }
 
@@ -557,7 +557,7 @@ void sha256_33(const std::uint8_t* pubkey33, std::uint8_t* out32) noexcept {
     sha256_compress(block, state);
 
     for (int i = 0; i < 8; ++i) {
-        store_be32(out32 + i * 4, state[i]);
+        store_be32(out32 + static_cast<std::size_t>(i) * 4, state[i]);
     }
 }
 
@@ -574,7 +574,7 @@ void sha256_32(const std::uint8_t* in32, std::uint8_t* out32) noexcept {
     sha256_compress(block, state);
 
     for (int i = 0; i < 8; ++i) {
-        store_be32(out32 + i * 4, state[i]);
+        store_be32(out32 + static_cast<std::size_t>(i) * 4, state[i]);
     }
 }
 
@@ -655,7 +655,7 @@ std::array<std::uint8_t, 20> ripemd160(const void* data, std::size_t len) noexce
         scalar::ripemd160_compress(block, state);
 
         std::array<std::uint8_t, 20> out;
-        for (int i = 0; i < 5; ++i) store_le32(out.data() + i * 4, state[i]);
+        for (int i = 0; i < 5; ++i) store_le32(out.data() + static_cast<std::size_t>(i) * 4, state[i]);
         return out;
     }
 

--- a/cpu/src/keccak256.cpp
+++ b/cpu/src/keccak256.cpp
@@ -139,7 +139,7 @@ std::array<std::uint8_t, 32> Keccak256State::finalize() {
     // Squeeze: extract first 32 bytes (256 bits)
     std::array<std::uint8_t, 32> output;
     for (int i = 0; i < 4; ++i) {
-        std::memcpy(output.data() + i * 8, &state[i], 8);
+        std::memcpy(output.data() + static_cast<std::size_t>(i) * 8, &state[i], 8);
     }
     return output;
 }

--- a/cpu/src/multiscalar.cpp
+++ b/cpu/src/multiscalar.cpp
@@ -10,7 +10,6 @@ namespace secp256k1 {
 
 using fast::Scalar;
 using fast::Point;
-using fast::FieldElement;
 
 // -- Window Width Selection ---------------------------------------------------
 

--- a/cpu/src/precompute.cpp
+++ b/cpu/src/precompute.cpp
@@ -727,7 +727,7 @@ Limbs4 mul_shift_round(const Limbs4& value, const std::array<std::uint64_t, N>& 
     // Add 2^(shift-1) for rounding (if shift>0)
     if (shift > 0) {
         unsigned const add_bit = shift - 1;
-        std::size_t limb_index = add_bit / 64U;
+        std::size_t const limb_index = add_bit / 64U;
         unsigned const bit_index = add_bit % 64U;
         if (limb_index < wide.size()) {
             std::uint64_t mask = 1ULL << bit_index;
@@ -847,8 +847,9 @@ template <std::size_t N>
             // Decrement qhat and adjust rhat
             --qhat;
             std::uint64_t const new_rhat = rhat + v_hi;
+            (void)rhat;
             if (new_rhat < rhat) { // overflow => break
-                rhat = new_rhat; break;
+                break;
             }
             rhat = new_rhat;
         }
@@ -1702,10 +1703,12 @@ static Scalar barrett_reduce_512(const std::array<std::uint64_t, 8>& wide) {
         if (ge_n) {
             // Subtract n once using intrinsics
             unsigned char borrow = 0;
+            (void)borrow;
             borrow = COMPAT_SUBBORROW_U64(borrow, low_limbs[0], N[0], &low_limbs[0]);
             borrow = COMPAT_SUBBORROW_U64(borrow, low_limbs[1], N[1], &low_limbs[1]);
             borrow = COMPAT_SUBBORROW_U64(borrow, low_limbs[2], N[2], &low_limbs[2]);
             borrow = COMPAT_SUBBORROW_U64(borrow, low_limbs[3], N[3], &low_limbs[3]);
+            (void)borrow;
         }
         
 #if SECP256K1_PROFILE_DECOMP
@@ -1830,10 +1833,12 @@ static JSF_Result compute_jsf(const Scalar& k1, const Scalar& k2) {
             unsigned char borrow = 0;
             std::uint64_t tmp = 0;
             borrow = COMPAT_SUBBORROW_U64(borrow, a[0], static_cast<std::uint64_t>(static_cast<int64_t>(u1)), &tmp); a[0] = tmp;
+            (void)borrow;
             borrow = COMPAT_SUBBORROW_U64(borrow, a[1], 0ULL, &tmp); a[1] = tmp;
             borrow = COMPAT_SUBBORROW_U64(borrow, a[2], 0ULL, &tmp); a[2] = tmp;
             borrow = COMPAT_SUBBORROW_U64(borrow, a[3], 0ULL, &tmp); a[3] = tmp;
             borrow = COMPAT_SUBBORROW_U64(borrow, a[4], 0ULL, &tmp); a[4] = tmp;
+            (void)borrow;
         }
         a[0] = (a[0] >> 1) | (a[1] << 63);
         a[1] = (a[1] >> 1) | (a[2] << 63);
@@ -1844,12 +1849,14 @@ static JSF_Result compute_jsf(const Scalar& k1, const Scalar& k2) {
         // Update b := (b - u2) >> 1
         if (u2 != 0) {
             unsigned char borrow = 0;
+            (void)borrow;
             std::uint64_t tmp = 0;
             borrow = COMPAT_SUBBORROW_U64(borrow, b[0], static_cast<std::uint64_t>(static_cast<int64_t>(u2)), &tmp); b[0] = tmp;
             borrow = COMPAT_SUBBORROW_U64(borrow, b[1], 0ULL, &tmp); b[1] = tmp;
             borrow = COMPAT_SUBBORROW_U64(borrow, b[2], 0ULL, &tmp); b[2] = tmp;
             borrow = COMPAT_SUBBORROW_U64(borrow, b[3], 0ULL, &tmp); b[3] = tmp;
             borrow = COMPAT_SUBBORROW_U64(borrow, b[4], 0ULL, &tmp); b[4] = tmp;
+            (void)borrow;
         }
         b[0] = (b[0] >> 1) | (b[1] << 63);
         b[1] = (b[1] >> 1) | (b[2] << 63);
@@ -1913,10 +1920,12 @@ static JSF_Result compute_jsf(const Scalar& k1, const Scalar& k2) {
     
     Limbs4 result;
     unsigned char carry = 0;
+    (void)carry;
     carry = COMPAT_ADDCARRY_U64(0, a[0], b[0], &result[0]);
     carry = COMPAT_ADDCARRY_U64(carry, a[1], b[1], &result[1]);
     carry = COMPAT_ADDCARRY_U64(carry, a[2], b[2], &result[2]);
     carry = COMPAT_ADDCARRY_U64(carry, a[3], b[3], &result[3]);
+    (void)carry;
     
     // Check if result >= n
     bool const ge_n = (result[3] > N[3]) ||
@@ -1927,10 +1936,12 @@ static JSF_Result compute_jsf(const Scalar& k1, const Scalar& k2) {
     if (ge_n) {
         // Subtract n
         unsigned char borrow = 0;
+        (void)borrow;
         borrow = COMPAT_SUBBORROW_U64(0, result[0], N[0], &result[0]);
         borrow = COMPAT_SUBBORROW_U64(borrow, result[1], N[1], &result[1]);
         borrow = COMPAT_SUBBORROW_U64(borrow, result[2], N[2], &result[2]);
         borrow = COMPAT_SUBBORROW_U64(borrow, result[3], N[3], &result[3]);
+        (void)borrow;
     }
     
     return result;
@@ -2865,6 +2876,7 @@ std::vector<int32_t> compute_wnaf(const Scalar& scalar, unsigned window_bits) {
                 // This creates the non-adjacent property
                 const auto add_val = static_cast<std::uint64_t>(-digit);
                 unsigned char carry = 0;
+                (void)carry;
                 std::uint64_t tmp = 0;
                 carry = COMPAT_ADDCARRY_U64(carry, k[0], add_val, &tmp); k[0] = tmp;
                 carry = COMPAT_ADDCARRY_U64(carry, k[1], 0ULL, &tmp); k[1] = tmp;
@@ -2876,6 +2888,7 @@ std::vector<int32_t> compute_wnaf(const Scalar& scalar, unsigned window_bits) {
                 
                 // Subtract digit from k
                 unsigned char borrow = 0;
+                (void)borrow;
                 std::uint64_t tmp = 0;
                 borrow = COMPAT_SUBBORROW_U64(borrow, k[0], static_cast<std::uint64_t>(digit), &tmp); k[0] = tmp;
                 borrow = COMPAT_SUBBORROW_U64(borrow, k[1], 0ULL, &tmp); k[1] = tmp;
@@ -2943,6 +2956,7 @@ void compute_wnaf_into(const Scalar& scalar,
                 digit = chunk - window_size;
                 const auto add_val = static_cast<std::uint64_t>(-digit);
                 unsigned char carry = 0;
+                (void)carry;
                 std::uint64_t tmp = 0;
                 carry = COMPAT_ADDCARRY_U64(carry, k[0], add_val, &tmp); k[0] = tmp;
                 carry = COMPAT_ADDCARRY_U64(carry, k[1], 0ULL, &tmp); k[1] = tmp;
@@ -2952,6 +2966,7 @@ void compute_wnaf_into(const Scalar& scalar,
             } else {
                 digit = chunk;
                 unsigned char borrow = 0;
+                (void)borrow;
                 std::uint64_t tmp = 0;
                 borrow = COMPAT_SUBBORROW_U64(borrow, k[0], static_cast<std::uint64_t>(digit), &tmp); k[0] = tmp;
                 borrow = COMPAT_SUBBORROW_U64(borrow, k[1], 0ULL, &tmp); k[1] = tmp;

--- a/cpu/src/scalar.cpp
+++ b/cpu/src/scalar.cpp
@@ -870,7 +870,9 @@ static void update_de_30(S30& d, S30& e, const T2x2& t, const ModInfo& mod) {
     int32_t di, ei, md, me, sd, se;
     int64_t cd, ce;
 
+    // cppcheck-suppress shiftTooManyBitsSigned
     sd = d.v[8] >> 31;
+    // cppcheck-suppress shiftTooManyBitsSigned
     se = e.v[8] >> 31;
     md = (u & sd) + (v & se);
     me = (q & sd) + (r & se);
@@ -930,6 +932,7 @@ static void normalize_30(S30& r, int32_t sign, const ModInfo& mod) {
             r5=r.v[5], r6=r.v[6], r7=r.v[7], r8=r.v[8];
     int32_t cond_add, cond_negate;
 
+    // cppcheck-suppress shiftTooManyBitsSigned
     cond_add = r8 >> 31;
     r0 += mod.modulus.v[0] & cond_add;
     r1 += mod.modulus.v[1] & cond_add;
@@ -940,6 +943,7 @@ static void normalize_30(S30& r, int32_t sign, const ModInfo& mod) {
     r6 += mod.modulus.v[6] & cond_add;
     r7 += mod.modulus.v[7] & cond_add;
     r8 += mod.modulus.v[8] & cond_add;
+    // cppcheck-suppress shiftTooManyBitsSigned
     cond_negate = sign >> 31;
     r0 = (r0 ^ cond_negate) - cond_negate;
     r1 = (r1 ^ cond_negate) - cond_negate;
@@ -959,6 +963,7 @@ static void normalize_30(S30& r, int32_t sign, const ModInfo& mod) {
     r7 += r6 >> 30; r6 &= M30;
     r8 += r7 >> 30; r7 &= M30;
 
+    // cppcheck-suppress shiftTooManyBitsSigned
     cond_add = r8 >> 31;
     r0 += mod.modulus.v[0] & cond_add;
     r1 += mod.modulus.v[1] & cond_add;
@@ -1045,8 +1050,11 @@ static limbs4 inverse_impl(const limbs4& x) {
         }
 
         int32_t fn = f.v[len - 1], gn = g.v[len - 1];
+        // cppcheck-suppress shiftTooManyBitsSigned
         int32_t cond = ((int32_t)len - 2) >> 31;
+        // cppcheck-suppress shiftTooManyBitsSigned
         cond |= fn ^ (fn >> 31);
+        // cppcheck-suppress shiftTooManyBitsSigned
         cond |= gn ^ (gn >> 31);
         if (cond == 0) {
             f.v[len - 2] |= (uint32_t)fn << 30;

--- a/cpu/src/schnorr.cpp
+++ b/cpu/src/schnorr.cpp
@@ -22,7 +22,6 @@ using FE52 = fast::FieldElement52;
 // variable-time paths (point.cpp batch inverse, verify Y-parity).
 
 // -- Shared BIP-340 tagged-hash midstates (from tagged_hash.hpp) ---------------
-using detail::make_tag_midstate;
 using detail::g_aux_midstate;
 using detail::g_nonce_midstate;
 using detail::g_challenge_midstate;

--- a/cpu/src/selftest.cpp
+++ b/cpu/src/selftest.cpp
@@ -23,13 +23,13 @@
 
 // ESP32/STM32 platform: use printf instead of iostream
 #if defined(SECP256K1_PLATFORM_ESP32) || defined(ESP_PLATFORM) || defined(IDF_VER) || defined(SECP256K1_PLATFORM_STM32)
-    #define SELFTEST_PRINT(...) printf(__VA_ARGS__)
+    #define SELFTEST_PRINT(...) (void)printf(__VA_ARGS__)
 #else
     #include <iostream>
     #include <fstream>
     #include <sstream>
     #include <iomanip>
-    #define SELFTEST_PRINT(...) printf(__VA_ARGS__)
+    #define SELFTEST_PRINT(...) (void)printf(__VA_ARGS__)
 #endif
 
 namespace secp256k1::fast {
@@ -1318,7 +1318,7 @@ bool Selftest(bool verbose, SelftestMode mode, uint64_t seed) {
         int vi = 0;
         for (const auto& vec : TEST_VECTORS) {
             char vname[48];
-            std::snprintf(vname, sizeof(vname), "scalar_mul_vector_%d", ++vi);
+            (void)std::snprintf(vname, sizeof(vname), "scalar_mul_vector_%d", ++vi);
             tally(total, passed, vname, test_scalar_mul(vec, verbose));
         }
     }

--- a/cpu/tests/diag_scalar_mul.cpp
+++ b/cpu/tests/diag_scalar_mul.cpp
@@ -122,13 +122,13 @@ static const SC S_OFFSET = SC::from_limbs({0, 0, 1, 0});
     // Print window digits for v1 and v2
     printf("  v1 digits (group 25..0): ");
     for (int g = 25; g >= 0; --g) {
-        std::uint64_t const w = ct::scalar_window(v1, g*5, 5);
+        std::uint64_t const w = ct::scalar_window(v1, static_cast<std::size_t>(g) * 5, 5);
         printf("%02lu ", (unsigned long)w);
     }
     printf("\n");
     printf("  v2 digits (group 25..0): ");
     for (int g = 25; g >= 0; --g) {
-        std::uint64_t const w = ct::scalar_window(v2, g*5, 5);
+        std::uint64_t const w = ct::scalar_window(v2, static_cast<std::size_t>(g) * 5, 5);
         printf("%02lu ", (unsigned long)w);
     }
     printf("\n");

--- a/cpu/tests/test_arithmetic_correctness.cpp
+++ b/cpu/tests/test_arithmetic_correctness.cpp
@@ -338,7 +338,7 @@ static bool test_kq_random() {
     std::cout << "+==========================================================+" << '\n';
     
     Point const G = Point::generator();
-    std::mt19937_64 rng(12345);
+    std::mt19937_64 rng(12345);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     int passed = 0;
     int const total = 10;
     

--- a/cpu/tests/test_batch_add_affine.cpp
+++ b/cpu/tests/test_batch_add_affine.cpp
@@ -24,14 +24,14 @@ static void check(bool cond, const char* name) {
         ++g_pass;
     } else {
         ++g_fail;
-        std::printf("  FAIL: %s\n", name);
+        (void)std::printf("  FAIL: %s\n", name);
     }
 }
 
 // -- Test 1: Precompute G-multiples table -------------------------------------
 
 static void test_precompute_g_multiples() {
-    std::printf("[BatchAffine] Precompute G-multiples table...\n");
+    (void)std::printf("[BatchAffine] Precompute G-multiples table...\n");
 
     constexpr std::size_t N = 64;
     auto table = precompute_g_multiples(N);
@@ -46,8 +46,8 @@ static void test_precompute_g_multiples() {
         FieldElement const expected_y = current.y();
 
         char label_x[64], label_y[64];
-        std::snprintf(label_x, sizeof(label_x), "table[%zu].x == %zuG.x", i, i + 1);
-        std::snprintf(label_y, sizeof(label_y), "table[%zu].y == %zuG.y", i, i + 1);
+        (void)std::snprintf(label_x, sizeof(label_x), "table[%zu].x == %zuG.x", i, i + 1);
+        (void)std::snprintf(label_y, sizeof(label_y), "table[%zu].y == %zuG.y", i, i + 1);
 
         check(table[i].x == expected_x, label_x);
         check(table[i].y == expected_y, label_y);
@@ -55,13 +55,13 @@ static void test_precompute_g_multiples() {
         current.next_inplace();
     }
 
-    std::printf("  Verified %zu G-multiples\n", N);
+    (void)std::printf("  Verified %zu G-multiples\n", N);
 }
 
 // -- Test 2: batch_add_affine_x correctness ----------------------------------
 
 static void test_batch_add_x_correctness() {
-    std::printf("[BatchAffine] batch_add_affine_x correctness...\n");
+    (void)std::printf("[BatchAffine] batch_add_affine_x correctness...\n");
 
     constexpr std::size_t BATCH = 128;
     auto g_table = precompute_g_multiples(BATCH);
@@ -84,7 +84,7 @@ static void test_batch_add_x_correctness() {
         // This is the degenerate doubling case, handled correctly by sentinel.
         if (i + 1 == 42) {
             char label[80];
-            std::snprintf(label, sizeof(label), "P + %zuG: degenerate (dx=0) -> sentinel zero", i + 1);
+            (void)std::snprintf(label, sizeof(label), "P + %zuG: degenerate (dx=0) -> sentinel zero", i + 1);
             check(out_x[i] == fe_zero, label);
             continue;
         }
@@ -94,17 +94,17 @@ static void test_batch_add_x_correctness() {
         FieldElement const expected_x = expected.x();
 
         char label[64];
-        std::snprintf(label, sizeof(label), "P + %zuG == %zuG (x-coord)", i + 1, 42 + i + 1);
+        (void)std::snprintf(label, sizeof(label), "P + %zuG == %zuG (x-coord)", i + 1, 42 + i + 1);
         check(out_x[i] == expected_x, label);
     }
 
-    std::printf("  Verified %zu batch additions\n", BATCH);
+    (void)std::printf("  Verified %zu batch additions\n", BATCH);
 }
 
 // -- Test 3: batch_add_affine_xy correctness ---------------------------------
 
 static void test_batch_add_xy_correctness() {
-    std::printf("[BatchAffine] batch_add_affine_xy correctness...\n");
+    (void)std::printf("[BatchAffine] batch_add_affine_xy correctness...\n");
 
     constexpr std::size_t BATCH = 64;
     auto g_table = precompute_g_multiples(BATCH);
@@ -125,19 +125,19 @@ static void test_batch_add_xy_correctness() {
         Point const expected = scalar_mul_generator(s);
 
         char label_x[64], label_y[64];
-        std::snprintf(label_x, sizeof(label_x), "xy[%zu].x correct", i);
-        std::snprintf(label_y, sizeof(label_y), "xy[%zu].y correct", i);
+        (void)std::snprintf(label_x, sizeof(label_x), "xy[%zu].x correct", i);
+        (void)std::snprintf(label_y, sizeof(label_y), "xy[%zu].y correct", i);
         check(out_x[i] == expected.x(), label_x);
         check(out_y[i] == expected.y(), label_y);
     }
 
-    std::printf("  Verified %zu XY results\n", BATCH);
+    (void)std::printf("  Verified %zu XY results\n", BATCH);
 }
 
 // -- Test 4: Bidirectional batch add ------------------------------------------
 
 static void test_bidirectional() {
-    std::printf("[BatchAffine] Bidirectional batch add...\n");
+    (void)std::printf("[BatchAffine] Bidirectional batch add...\n");
 
     constexpr std::size_t BATCH = 32;
     auto g_table = precompute_g_multiples(BATCH);
@@ -166,19 +166,19 @@ static void test_bidirectional() {
         Point const exp_bwd = scalar_mul_generator(s_bwd);
 
         char label_f[64], label_b[64];
-        std::snprintf(label_f, sizeof(label_f), "fwd[%zu] == %zuG", i, 500 + i + 1);
-        std::snprintf(label_b, sizeof(label_b), "bwd[%zu] == %zuG", i, 500 - i - 1);
+        (void)std::snprintf(label_f, sizeof(label_f), "fwd[%zu] == %zuG", i, 500 + i + 1);
+        (void)std::snprintf(label_b, sizeof(label_b), "bwd[%zu] == %zuG", i, 500 - i - 1);
         check(out_fwd[i] == exp_fwd.x(), label_f);
         check(out_bwd[i] == exp_bwd.x(), label_b);
     }
 
-    std::printf("  Verified %zu bidirectional pairs\n", BATCH);
+    (void)std::printf("  Verified %zu bidirectional pairs\n", BATCH);
 }
 
 // -- Test 5: Parity extraction ------------------------------------------------
 
 static void test_parity() {
-    std::printf("[BatchAffine] Y-parity extraction...\n");
+    (void)std::printf("[BatchAffine] Y-parity extraction...\n");
 
     constexpr std::size_t BATCH = 32;
     auto g_table = precompute_g_multiples(BATCH);
@@ -202,17 +202,17 @@ static void test_parity() {
         uint8_t const expected_parity = y_bytes[31] & 1;
 
         char label[64];
-        std::snprintf(label, sizeof(label), "parity[%zu] correct", i);
+        (void)std::snprintf(label, sizeof(label), "parity[%zu] correct", i);
         check(out_parity[i] == expected_parity, label);
     }
 
-    std::printf("  Verified %zu parity values\n", BATCH);
+    (void)std::printf("  Verified %zu parity values\n", BATCH);
 }
 
 // -- Test 6: Arbitrary point multiples ----------------------------------------
 
 static void test_arbitrary_point_table() {
-    std::printf("[BatchAffine] Arbitrary point multiples table...\n");
+    (void)std::printf("[BatchAffine] Arbitrary point multiples table...\n");
 
     // Use 7*G as base
     Scalar const s7 = Scalar::from_uint64(7);
@@ -229,18 +229,18 @@ static void test_arbitrary_point_table() {
         Point const expected = scalar_mul_generator(s);
 
         char label[64];
-        std::snprintf(label, sizeof(label), "arb_table[%zu] == %zuQ", i, i + 1);
+        (void)std::snprintf(label, sizeof(label), "arb_table[%zu] == %zuQ", i, i + 1);
         check(table[i].x == expected.x(), label);
         check(table[i].y == expected.y(), label);
     }
 
-    std::printf("  Verified %zu arbitrary multiples\n", N);
+    (void)std::printf("  Verified %zu arbitrary multiples\n", N);
 }
 
 // -- Test 7: Large batch (search-scale) ---------------------------------------
 
 static void test_large_batch() {
-    std::printf("[BatchAffine] Large batch (1024 points)...\n");
+    (void)std::printf("[BatchAffine] Large batch (1024 points)...\n");
 
     constexpr std::size_t BATCH = 1024;
     
@@ -248,7 +248,7 @@ static void test_large_batch() {
     auto g_table = precompute_g_multiples(BATCH);
     auto t1 = std::chrono::high_resolution_clock::now();
     double const precomp_us = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count());
-    std::printf("  Precompute %zu G-multiples: %.1f us\n", BATCH, precomp_us);
+    (void)std::printf("  Precompute %zu G-multiples: %.1f us\n", BATCH, precomp_us);
 
     // Base: P = 999999*G
     Scalar const sbase = Scalar::from_uint64(999999);
@@ -273,8 +273,8 @@ static void test_large_batch() {
     double const per_batch_us = total_ns / ITERS / 1000.0;
     double const per_point_ns = total_ns / ITERS / BATCH;
 
-    std::printf("  Batch %zu: %.1f us total, %.1f ns/point\n", BATCH, per_batch_us, per_point_ns);
-    std::printf("  Throughput: %.2f Mpoints/s (single thread)\n", 1e9 / per_point_ns / 1e6);
+    (void)std::printf("  Batch %zu: %.1f us total, %.1f ns/point\n", BATCH, per_batch_us, per_point_ns);
+    (void)std::printf("  Throughput: %.2f Mpoints/s (single thread)\n", 1e9 / per_point_ns / 1e6);
 
     // Spot-check first and last
     {
@@ -292,7 +292,7 @@ static void test_large_batch() {
 // -- Test 8: Edge case -- empty batch ------------------------------------------
 
 static void test_empty() {
-    std::printf("[BatchAffine] Empty batch...\n");
+    (void)std::printf("[BatchAffine] Empty batch...\n");
     std::vector<FieldElement> scratch;
     FieldElement const base_x = FieldElement::from_uint64(1);
     FieldElement const base_y = FieldElement::from_uint64(2);
@@ -303,7 +303,7 @@ static void test_empty() {
 // -- Test 9: Negate table correctness -----------------------------------------
 
 static void test_negate_table() {
-    std::printf("[BatchAffine] Negate table...\n");
+    (void)std::printf("[BatchAffine] Negate table...\n");
 
     constexpr std::size_t N = 16;
     auto table = precompute_g_multiples(N);
@@ -315,18 +315,18 @@ static void test_negate_table() {
         Point const expected = scalar_mul_generator(s).negate();
 
         char label[64];
-        std::snprintf(label, sizeof(label), "neg_table[%zu] == -%zuG", i, i + 1);
+        (void)std::snprintf(label, sizeof(label), "neg_table[%zu] == -%zuG", i, i + 1);
         check(neg[i].x == expected.x(), label);
         check(neg[i].y == expected.y(), label);
     }
 
-    std::printf("  Verified %zu negated points\n", N);
+    (void)std::printf("  Verified %zu negated points\n", N);
 }
 
 // -- Entry point --------------------------------------------------------------
 
 int test_batch_add_affine_run() {
-    std::printf("\n=== Affine Batch Addition Tests ===\n");
+    (void)std::printf("\n=== Affine Batch Addition Tests ===\n");
 
     test_empty();
     test_precompute_g_multiples();
@@ -338,7 +338,7 @@ int test_batch_add_affine_run() {
     test_negate_table();
     test_large_batch();
 
-    std::printf("\n  Affine batch add: %d passed, %d failed\n", g_pass, g_fail);
+    (void)std::printf("\n  Affine batch add: %d passed, %d failed\n", g_pass, g_fail);
     return g_fail;
 }
 

--- a/cpu/tests/test_bip32.cpp
+++ b/cpu/tests/test_bip32.cpp
@@ -10,8 +10,6 @@
 #include <array>
 
 using namespace secp256k1;
-using fast::Scalar;
-using fast::Point;
 
 static int tests_run = 0;
 static int tests_passed = 0;

--- a/cpu/tests/test_bip32_vectors.cpp
+++ b/cpu/tests/test_bip32_vectors.cpp
@@ -30,8 +30,8 @@ static int g_tests_passed = 0;
 
 #define CHECK(cond, msg) do { \
     ++g_tests_run; \
-    if (cond) { ++g_tests_passed; printf("  [PASS] %s\n", msg); } \
-    else { printf("  [FAIL] %s\n", msg); } \
+    if (cond) { ++g_tests_passed; (void)printf("  [PASS] %s\n", msg); } \
+    else { (void)printf("  [FAIL] %s\n", msg); } \
 } while(0)
 
 // -- Hex utility (no heap) ----------------------------------------------------
@@ -73,10 +73,10 @@ static void verify_chain(const ExtendedKey& master,
         hex_to_bytes(vecs[0].chain_code, expected_cc, 32);
         hex_to_bytes(vecs[0].priv_key, expected_key, 32);
 
-        std::snprintf(label, sizeof(label), "%s m: chain_code", tv_label);
+        (void)std::snprintf(label, sizeof(label), "%s m: chain_code", tv_label);
         CHECK(std::memcmp(master.chain_code.data(), expected_cc, 32) == 0, label);
 
-        std::snprintf(label, sizeof(label), "%s m: priv_key", tv_label);
+        (void)std::snprintf(label, sizeof(label), "%s m: priv_key", tv_label);
         CHECK(std::memcmp(master.key.data(), expected_key, 32) == 0, label);
 
         // Verify public key
@@ -85,7 +85,7 @@ static void verify_chain(const ExtendedKey& master,
             hex_to_bytes(vecs[0].pub_key, expected_pub, 33);
             auto pub_point = master.public_key();
             auto pub_bytes = pub_point.to_compressed();
-            std::snprintf(label, sizeof(label), "%s m: pub_key", tv_label);
+            (void)std::snprintf(label, sizeof(label), "%s m: pub_key", tv_label);
             CHECK(std::memcmp(pub_bytes.data(), expected_pub, 33) == 0, label);
         }
     }
@@ -93,7 +93,7 @@ static void verify_chain(const ExtendedKey& master,
     // Derive and verify each child level
     for (int i = 1; i < count; ++i) {
         auto [child, ok] = bip32_derive_path(master, vecs[i].path);
-        std::snprintf(label, sizeof(label), "%s %s: derivation succeeds", tv_label, vecs[i].path);
+        (void)std::snprintf(label, sizeof(label), "%s %s: derivation succeeds", tv_label, vecs[i].path);
         CHECK(ok, label);
         if (!ok) continue;
 
@@ -101,10 +101,10 @@ static void verify_chain(const ExtendedKey& master,
         hex_to_bytes(vecs[i].chain_code, expected_cc, 32);
         hex_to_bytes(vecs[i].priv_key, expected_key, 32);
 
-        std::snprintf(label, sizeof(label), "%s %s: chain_code", tv_label, vecs[i].path);
+        (void)std::snprintf(label, sizeof(label), "%s %s: chain_code", tv_label, vecs[i].path);
         CHECK(std::memcmp(child.chain_code.data(), expected_cc, 32) == 0, label);
 
-        std::snprintf(label, sizeof(label), "%s %s: priv_key", tv_label, vecs[i].path);
+        (void)std::snprintf(label, sizeof(label), "%s %s: priv_key", tv_label, vecs[i].path);
         CHECK(std::memcmp(child.key.data(), expected_key, 32) == 0, label);
 
         // Verify public key
@@ -113,7 +113,7 @@ static void verify_chain(const ExtendedKey& master,
             hex_to_bytes(vecs[i].pub_key, expected_pub, 33);
             auto pub_point = child.public_key();
             auto pub_bytes = pub_point.to_compressed();
-            std::snprintf(label, sizeof(label), "%s %s: pub_key", tv_label, vecs[i].path);
+            (void)std::snprintf(label, sizeof(label), "%s %s: pub_key", tv_label, vecs[i].path);
             CHECK(std::memcmp(pub_bytes.data(), expected_pub, 33) == 0, label);
         }
     }
@@ -151,7 +151,7 @@ static const ChainVector TV1[] = {
 };
 
 static void test_bip32_tv1() {
-    printf("\n--- BIP-32 Test Vector 1 ---\n");
+    (void)printf("\n--- BIP-32 Test Vector 1 ---\n");
     std::uint8_t seed[16];
     hex_to_bytes("000102030405060708090a0b0c0d0e0f", seed, 16);
     auto [master, ok] = bip32_master_key(seed, 16);
@@ -194,7 +194,7 @@ static const ChainVector TV2[] = {
 };
 
 static void test_bip32_tv2() {
-    printf("\n--- BIP-32 Test Vector 2 ---\n");
+    (void)printf("\n--- BIP-32 Test Vector 2 ---\n");
     // 64-byte seed
     std::uint8_t seed[64];
     hex_to_bytes(
@@ -224,7 +224,7 @@ static const ChainVector TV3[] = {
 };
 
 static void test_bip32_tv3() {
-    printf("\n--- BIP-32 Test Vector 3 (leading zeros retention) ---\n");
+    (void)printf("\n--- BIP-32 Test Vector 3 (leading zeros retention) ---\n");
     std::uint8_t seed[64];
     hex_to_bytes(
         "4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11e"
@@ -257,7 +257,7 @@ static const ChainVector TV4[] = {
 };
 
 static void test_bip32_tv4() {
-    printf("\n--- BIP-32 Test Vector 4 (leading zeros, hardened children) ---\n");
+    (void)printf("\n--- BIP-32 Test Vector 4 (leading zeros, hardened children) ---\n");
     std::uint8_t seed[32];
     hex_to_bytes("3ddd5602285899a946114506157c7997e5444528f3003f6134712147db19b678",
                  seed, 32);
@@ -274,7 +274,7 @@ static void test_bip32_tv4() {
 // ============================================================================
 
 static void test_bip32_tv5_serialization() {
-    printf("\n--- BIP-32 Test Vector 5 (serialization) ---\n");
+    (void)printf("\n--- BIP-32 Test Vector 5 (serialization) ---\n");
 
     // Use TV1 seed
     std::uint8_t seed[16];
@@ -354,7 +354,7 @@ static void test_bip32_tv5_serialization() {
 // ============================================================================
 
 static void test_bip32_public_derivation() {
-    printf("\n--- BIP-32 Public Derivation Consistency ---\n");
+    (void)printf("\n--- BIP-32 Public Derivation Consistency ---\n");
 
     // TV1: derive m/0'/1 (hardened then normal)
     std::uint8_t seed[16];
@@ -396,7 +396,7 @@ static void test_bip32_public_derivation() {
 // ============================================================================
 
 int test_bip32_vectors_run() {
-    printf("=== BIP-32 Official Test Vectors (TV1-TV5) ===\n");
+    (void)printf("=== BIP-32 Official Test Vectors (TV1-TV5) ===\n");
 
     test_bip32_tv1();
     test_bip32_tv2();
@@ -405,7 +405,7 @@ int test_bip32_vectors_run() {
     test_bip32_tv5_serialization();
     test_bip32_public_derivation();
 
-    printf("\n=== BIP-32 Vectors: %d/%d passed ===\n", g_tests_passed, g_tests_run);
+    (void)printf("\n=== BIP-32 Vectors: %d/%d passed ===\n", g_tests_passed, g_tests_run);
     return (g_tests_passed == g_tests_run) ? 0 : 1;
 }
 

--- a/cpu/tests/test_bip340_vectors.cpp
+++ b/cpu/tests/test_bip340_vectors.cpp
@@ -33,7 +33,7 @@ static int tests_passed = 0;
 static void hex_to_bytes(const char* hex, uint8_t* out, size_t len) {
     for (size_t i = 0; i < len; ++i) {
         unsigned hi = 0, lo = 0;
-        char c0 = hex[i * 2], c1 = hex[i * 2 + 1];
+        char const c0 = hex[i * 2], c1 = hex[i * 2 + 1];
         if (c0 >= '0' && c0 <= '9') { hi = static_cast<unsigned>(c0 - '0');
         } else if (c0 >= 'a' && c0 <= 'f') { hi = static_cast<unsigned>(c0 - 'a' + 10);
         } else if (c0 >= 'A' && c0 <= 'F') { hi = static_cast<unsigned>(c0 - 'A' + 10);

--- a/cpu/tests/test_coins.cpp
+++ b/cpu/tests/test_coins.cpp
@@ -41,7 +41,7 @@ static int tests_failed = 0;
     do { printf("FAIL: %s\n", msg); ++tests_failed; } while(0)
 
 #define ASSERT_TRUE(cond, msg) \
-    do { if (!(cond)) { FAIL(msg); return; } } while(0)
+    do { if (cond) { (void)0; } else { FAIL(msg); return; } } while(0)
 
 #define ASSERT_EQ(a, b, msg) \
     do { if ((a) != (b)) { FAIL(msg); return; } } while(0)
@@ -220,7 +220,8 @@ static void test_keccak256_abc() {
 static void test_keccak256_incremental() {
     TEST("Keccak-256: incremental == one-shot");
     
-    const std::uint8_t data[] = "hello world";
+    const char data_raw[] = "hello world";
+    const auto* data = reinterpret_cast<const std::uint8_t*>(data_raw);
     auto one_shot = secp256k1::coins::keccak256(data, 11);
     
     secp256k1::coins::Keccak256State state;

--- a/cpu/tests/test_comprehensive.cpp
+++ b/cpu/tests/test_comprehensive.cpp
@@ -572,7 +572,9 @@ static void test_field_optimal() {
     CHECK(from_optimal(to_optimal(pm1)) == pm1, "p-1 optimal roundtrip");
     
     // 6.6: Tier name is non-null
+    // cppcheck-suppress nullPointerRedundantCheck
     CHECK(kOptimalTierName != nullptr, "optimal tier name exists");
+    // cppcheck-suppress nullPointerRedundantCheck
     CHECK(std::strlen(kOptimalTierName) > 0, "optimal tier name non-empty");
     
     // 6.7: Multiple distinct values

--- a/cpu/tests/test_ecc_properties.cpp
+++ b/cpu/tests/test_ecc_properties.cpp
@@ -38,8 +38,8 @@ static int tests_passed = 0;
 
 #define CHECK(cond, msg) do { \
     ++tests_run; \
-    if (cond) { ++tests_passed; printf("  [PASS] %s\n", msg); } \
-    else { printf("  [FAIL] %s\n", msg); } \
+    if (cond) { ++tests_passed; (void)printf("  [PASS] %s\n", msg); } \
+    else { (void)printf("  [FAIL] %s\n", msg); } \
 } while(0)
 
 // Compare two points by compressed encoding (33 bytes)
@@ -89,7 +89,7 @@ static Point deterministic_point(uint64_t idx) {
 // -- property tests ----------------------------------------------------------
 
 static void test_identity_element() {
-    printf("\n--- Identity element: P + O == P ---\n");
+    (void)printf("\n--- Identity element: P + O == P ---\n");
 
     Point const G = Point::generator();
     Point const O = Point::infinity();
@@ -106,7 +106,7 @@ static void test_identity_element() {
 }
 
 static void test_inverse_element() {
-    printf("\n--- Inverse element: P + (-P) == O ---\n");
+    (void)printf("\n--- Inverse element: P + (-P) == O ---\n");
 
     Point const G = Point::generator();
     Point const neg_G = G.negate();
@@ -116,7 +116,7 @@ static void test_inverse_element() {
         Point const P = deterministic_point(i);
         Point const neg_P = P.negate();
         char buf[64];
-        std::snprintf(buf, sizeof(buf), "P_%llu + (-P_%llu) == O",
+        (void)std::snprintf(buf, sizeof(buf), "P_%llu + (-P_%llu) == O",
                       static_cast<unsigned long long>(i),
                       static_cast<unsigned long long>(i));
         CHECK(P.add(neg_P).is_infinity(), buf);
@@ -124,7 +124,7 @@ static void test_inverse_element() {
 }
 
 static void test_negate_involution() {
-    printf("\n--- Negate involution: -(-P) == P ---\n");
+    (void)printf("\n--- Negate involution: -(-P) == P ---\n");
 
     Point const G = Point::generator();
     CHECK(points_equal(G.negate().negate(), G), "-(-G) == G");
@@ -132,7 +132,7 @@ static void test_negate_involution() {
     for (uint64_t i = 1; i <= 5; ++i) {
         Point const P = deterministic_point(i);
         char buf[64];
-        std::snprintf(buf, sizeof(buf), "-(-P_%llu) == P_%llu",
+        (void)std::snprintf(buf, sizeof(buf), "-(-P_%llu) == P_%llu",
                       static_cast<unsigned long long>(i),
                       static_cast<unsigned long long>(i));
         CHECK(points_equal(P.negate().negate(), P), buf);
@@ -140,7 +140,7 @@ static void test_negate_involution() {
 }
 
 static void test_commutativity() {
-    printf("\n--- Commutativity: P + Q == Q + P ---\n");
+    (void)printf("\n--- Commutativity: P + Q == Q + P ---\n");
 
     for (uint64_t i = 0; i < 8; ++i) {
         Point const P = deterministic_point(i * 2);
@@ -148,7 +148,7 @@ static void test_commutativity() {
         Point const PQ = P.add(Q);
         Point const QP = Q.add(P);
         char buf[64];
-        std::snprintf(buf, sizeof(buf), "P_%llu + Q_%llu == Q_%llu + P_%llu",
+        (void)std::snprintf(buf, sizeof(buf), "P_%llu + Q_%llu == Q_%llu + P_%llu",
                       static_cast<unsigned long long>(i * 2),
                       static_cast<unsigned long long>(i * 2 + 1),
                       static_cast<unsigned long long>(i * 2 + 1),
@@ -158,7 +158,7 @@ static void test_commutativity() {
 }
 
 static void test_associativity() {
-    printf("\n--- Associativity: (P + Q) + R == P + (Q + R) ---\n");
+    (void)printf("\n--- Associativity: (P + Q) + R == P + (Q + R) ---\n");
 
     for (uint64_t i = 0; i < 5; ++i) {
         Point const P = deterministic_point(i * 3);
@@ -169,7 +169,7 @@ static void test_associativity() {
         Point const rhs = P.add(Q.add(R));
 
         char buf[80];
-        std::snprintf(buf, sizeof(buf), "(P_%llu + Q_%llu) + R_%llu == P_%llu + (Q_%llu + R_%llu)",
+        (void)std::snprintf(buf, sizeof(buf), "(P_%llu + Q_%llu) + R_%llu == P_%llu + (Q_%llu + R_%llu)",
                       static_cast<unsigned long long>(i * 3),
                       static_cast<unsigned long long>(i * 3 + 1),
                       static_cast<unsigned long long>(i * 3 + 2),
@@ -181,7 +181,7 @@ static void test_associativity() {
 }
 
 static void test_double_equals_add() {
-    printf("\n--- Double consistency: 2*P == P + P ---\n");
+    (void)printf("\n--- Double consistency: 2*P == P + P ---\n");
 
     Point const G = Point::generator();
     CHECK(points_equal(G.dbl(), G.add(G)), "2*G == G + G");
@@ -189,7 +189,7 @@ static void test_double_equals_add() {
     for (uint64_t i = 1; i <= 5; ++i) {
         Point const P = deterministic_point(i);
         char buf[64];
-        std::snprintf(buf, sizeof(buf), "2*P_%llu == P_%llu + P_%llu",
+        (void)std::snprintf(buf, sizeof(buf), "2*P_%llu == P_%llu + P_%llu",
                       static_cast<unsigned long long>(i),
                       static_cast<unsigned long long>(i),
                       static_cast<unsigned long long>(i));
@@ -198,7 +198,7 @@ static void test_double_equals_add() {
 }
 
 static void test_scalar_ring_distributivity() {
-    printf("\n--- Scalar ring: (a + b)*G == a*G + b*G ---\n");
+    (void)printf("\n--- Scalar ring: (a + b)*G == a*G + b*G ---\n");
 
     Point const G = Point::generator();
 
@@ -211,7 +211,7 @@ static void test_scalar_ring_distributivity() {
         Point const rhs = G.scalar_mul(a).add(G.scalar_mul(b));
 
         char buf[64];
-        std::snprintf(buf, sizeof(buf), "(a_%llu + b_%llu)*G == a_%llu*G + b_%llu*G",
+        (void)std::snprintf(buf, sizeof(buf), "(a_%llu + b_%llu)*G == a_%llu*G + b_%llu*G",
                       static_cast<unsigned long long>(i * 2),
                       static_cast<unsigned long long>(i * 2 + 1),
                       static_cast<unsigned long long>(i * 2),
@@ -221,7 +221,7 @@ static void test_scalar_ring_distributivity() {
 }
 
 static void test_scalar_mul_associativity() {
-    printf("\n--- Scalar associativity: (a*b)*G == a*(b*G) ---\n");
+    (void)printf("\n--- Scalar associativity: (a*b)*G == a*(b*G) ---\n");
 
     Point const G = Point::generator();
 
@@ -234,7 +234,7 @@ static void test_scalar_mul_associativity() {
         Point const rhs = G.scalar_mul(b).scalar_mul(a);
 
         char buf[64];
-        std::snprintf(buf, sizeof(buf), "(a_%llu * b_%llu)*G == a_%llu * (b_%llu * G)",
+        (void)std::snprintf(buf, sizeof(buf), "(a_%llu * b_%llu)*G == a_%llu * (b_%llu * G)",
                       static_cast<unsigned long long>(i * 2),
                       static_cast<unsigned long long>(i * 2 + 1),
                       static_cast<unsigned long long>(i * 2),
@@ -244,7 +244,7 @@ static void test_scalar_mul_associativity() {
 }
 
 static void test_distributivity() {
-    printf("\n--- Distributivity: k*(P + Q) == k*P + k*Q ---\n");
+    (void)printf("\n--- Distributivity: k*(P + Q) == k*P + k*Q ---\n");
 
     for (uint64_t i = 0; i < 8; ++i) {
         Scalar const k = deterministic_scalar(i + 300);
@@ -255,7 +255,7 @@ static void test_distributivity() {
         Point const rhs = P.scalar_mul(k).add(Q.scalar_mul(k));
 
         char buf[64];
-        std::snprintf(buf, sizeof(buf), "k_%llu * (P_%llu + Q_%llu) == k_%llu*P_%llu + k_%llu*Q_%llu",
+        (void)std::snprintf(buf, sizeof(buf), "k_%llu * (P_%llu + Q_%llu) == k_%llu*P_%llu + k_%llu*Q_%llu",
                       static_cast<unsigned long long>(i),
                       static_cast<unsigned long long>(i * 2),
                       static_cast<unsigned long long>(i * 2 + 1),
@@ -268,7 +268,7 @@ static void test_distributivity() {
 }
 
 static void test_generator_order() {
-    printf("\n--- Generator order: n*G == O ---\n");
+    (void)printf("\n--- Generator order: n*G == O ---\n");
 
     // secp256k1 order n
     Scalar const n = Scalar::from_hex(
@@ -295,7 +295,7 @@ static void test_generator_order() {
 }
 
 static void test_sub_consistency() {
-    printf("\n--- Subtraction: P - Q == P + (-Q) ---\n");
+    (void)printf("\n--- Subtraction: P - Q == P + (-Q) ---\n");
 
     for (uint64_t i = 0; i < 5; ++i) {
         Point const P = deterministic_point(i * 2 + 400);
@@ -307,7 +307,7 @@ static void test_sub_consistency() {
         // P - Q via scalar: P + (n-1)*Q (equivalent to P + (-Q))
         // We just verify the negate path is consistent
         char buf[64];
-        std::snprintf(buf, sizeof(buf), "P_%llu - Q_%llu == P_%llu + (-Q_%llu)",
+        (void)std::snprintf(buf, sizeof(buf), "P_%llu - Q_%llu == P_%llu + (-Q_%llu)",
                       static_cast<unsigned long long>(i * 2),
                       static_cast<unsigned long long>(i * 2 + 1),
                       static_cast<unsigned long long>(i * 2),
@@ -320,7 +320,7 @@ static void test_sub_consistency() {
 }
 
 static void test_scalar_mul_small_values() {
-    printf("\n--- Scalar mul small values: k*G consistency ---\n");
+    (void)printf("\n--- Scalar mul small values: k*G consistency ---\n");
 
     Point const G = Point::generator();
     Point acc = Point::infinity();
@@ -330,7 +330,7 @@ static void test_scalar_mul_small_values() {
         acc = acc.add(G);
         Point const via_mul = G.scalar_mul(Scalar::from_uint64(k));
         char buf[64];
-        std::snprintf(buf, sizeof(buf), "%llu*G == G+G+...+G (%llu times)",
+        (void)std::snprintf(buf, sizeof(buf), "%llu*G == G+G+...+G (%llu times)",
                       static_cast<unsigned long long>(k),
                       static_cast<unsigned long long>(k));
         CHECK(points_equal(via_mul, acc), buf);
@@ -338,7 +338,7 @@ static void test_scalar_mul_small_values() {
 }
 
 static void test_inplace_consistency() {
-    printf("\n--- In-place ops consistency ---\n");
+    (void)printf("\n--- In-place ops consistency ---\n");
 
     Point const G = Point::generator();
     Scalar const k = deterministic_scalar(500);
@@ -395,7 +395,7 @@ static void test_inplace_consistency() {
 }
 
 static void test_dual_scalar_mul() {
-    printf("\n--- Dual scalar mul: a*G + b*P ---\n");
+    (void)printf("\n--- Dual scalar mul: a*G + b*P ---\n");
 
     Point const G = Point::generator();
 
@@ -408,7 +408,7 @@ static void test_dual_scalar_mul() {
         Point const dual = Point::dual_scalar_mul_gen_point(a, b, P);
 
         char buf[64];
-        std::snprintf(buf, sizeof(buf), "dual_mul(%llu) == a*G + b*P",
+        (void)std::snprintf(buf, sizeof(buf), "dual_mul(%llu) == a*G + b*P",
                       static_cast<unsigned long long>(i));
         CHECK(points_equal(dual, expected), buf);
     }
@@ -417,9 +417,9 @@ static void test_dual_scalar_mul() {
 // -- entry points ------------------------------------------------------------
 
 int test_ecc_properties_run() {
-    printf("\n================================================================\n");
-    printf("  ECC Property-Based Tests (secp256k1 group-law invariants)\n");
-    printf("================================================================\n");
+    (void)printf("\n================================================================\n");
+    (void)printf("  ECC Property-Based Tests (secp256k1 group-law invariants)\n");
+    (void)printf("================================================================\n");
 
     tests_run = 0;
     tests_passed = 0;
@@ -439,9 +439,9 @@ int test_ecc_properties_run() {
     test_inplace_consistency();
     test_dual_scalar_mul();
 
-    printf("\n================================================================\n");
-    printf("  ECC Property Results: %d / %d passed\n", tests_passed, tests_run);
-    printf("================================================================\n");
+    (void)printf("\n================================================================\n");
+    (void)printf("  ECC Property Results: %d / %d passed\n", tests_passed, tests_run);
+    (void)printf("================================================================\n");
 
     return (tests_passed == tests_run) ? 0 : 1;
 }

--- a/cpu/tests/test_ecdh_recovery_taproot.cpp
+++ b/cpu/tests/test_ecdh_recovery_taproot.cpp
@@ -24,7 +24,6 @@
 using namespace secp256k1;
 using fast::Scalar;
 using fast::Point;
-using fast::FieldElement;
 
 static int g_pass = 0, g_fail = 0;
 
@@ -33,7 +32,7 @@ static void check(bool cond, const char* name) {
         ++g_pass;
     } else {
         ++g_fail;
-        std::printf("  FAIL: %s\n", name);
+        (void)std::printf("  FAIL: %s\n", name);
     }
 }
 
@@ -46,7 +45,7 @@ static std::array<uint8_t, 32> hex32(const char* hex) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
-        std::sscanf(hex + i * 2, "%02x", &val);
+        (void)std::sscanf(hex + i * 2, "%02x", &val);
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
@@ -60,7 +59,7 @@ static std::array<uint8_t, 32> hex32(const char* hex) {
 // ===============================================================================
 
 static void test_ecdh_basic() {
-    std::printf("[ECDH] Basic key exchange...\n");
+    (void)std::printf("[ECDH] Basic key exchange...\n");
 
     // Alice and Bob: generate keypairs
     auto sk_a = Scalar::from_hex(
@@ -81,7 +80,7 @@ static void test_ecdh_basic() {
 }
 
 static void test_ecdh_xonly() {
-    std::printf("[ECDH] X-only variant...\n");
+    (void)std::printf("[ECDH] X-only variant...\n");
 
     auto sk_a = Scalar::from_hex(
         "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798");
@@ -98,7 +97,7 @@ static void test_ecdh_xonly() {
 }
 
 static void test_ecdh_raw() {
-    std::printf("[ECDH] Raw x-coordinate...\n");
+    (void)std::printf("[ECDH] Raw x-coordinate...\n");
 
     auto sk_a = Scalar::from_hex(
         "0000000000000000000000000000000000000000000000000000000000000003");
@@ -120,7 +119,7 @@ static void test_ecdh_raw() {
 }
 
 static void test_ecdh_zero_key() {
-    std::printf("[ECDH] Edge: zero private key...\n");
+    (void)std::printf("[ECDH] Edge: zero private key...\n");
 
     auto sk_zero = Scalar::zero();
     auto pk = Point::generator();
@@ -130,7 +129,7 @@ static void test_ecdh_zero_key() {
 }
 
 static void test_ecdh_infinity() {
-    std::printf("[ECDH] Edge: infinity public key...\n");
+    (void)std::printf("[ECDH] Edge: infinity public key...\n");
 
     auto sk = Scalar::from_hex(
         "0000000000000000000000000000000000000000000000000000000000000001");
@@ -145,7 +144,7 @@ static void test_ecdh_infinity() {
 // ===============================================================================
 
 static void test_recovery_basic() {
-    std::printf("[Recovery] Basic sign + recover...\n");
+    (void)std::printf("[Recovery] Basic sign + recover...\n");
 
     auto sk = Scalar::from_hex(
         "0000000000000000000000000000000000000000000000000000000000000001");
@@ -166,7 +165,7 @@ static void test_recovery_basic() {
 }
 
 static void test_recovery_multiple_keys() {
-    std::printf("[Recovery] Multiple different private keys...\n");
+    (void)std::printf("[Recovery] Multiple different private keys...\n");
 
     const char* const test_keys[] = {
         "0000000000000000000000000000000000000000000000000000000000000002",
@@ -188,7 +187,7 @@ static void test_recovery_multiple_keys() {
 }
 
 static void test_recovery_compact_serialization() {
-    std::printf("[Recovery] Compact 65-byte serialization...\n");
+    (void)std::printf("[Recovery] Compact 65-byte serialization...\n");
 
     auto sk = Scalar::from_hex(
         "0000000000000000000000000000000000000000000000000000000000000005");
@@ -209,7 +208,7 @@ static void test_recovery_compact_serialization() {
 }
 
 static void test_recovery_wrong_recid() {
-    std::printf("[Recovery] Wrong recovery ID...\n");
+    (void)std::printf("[Recovery] Wrong recovery ID...\n");
 
     auto sk = Scalar::from_hex(
         "0000000000000000000000000000000000000000000000000000000000000001");
@@ -231,7 +230,7 @@ static void test_recovery_wrong_recid() {
 }
 
 static void test_recovery_invalid_sig() {
-    std::printf("[Recovery] Invalid signature (zero r/s)...\n");
+    (void)std::printf("[Recovery] Invalid signature (zero r/s)...\n");
 
     auto msg = hex32("0000000000000000000000000000000000000000000000000000000000000001");
 
@@ -263,7 +262,7 @@ static void test_recovery_invalid_sig() {
 // ===============================================================================
 
 static void test_taproot_tweak_hash() {
-    std::printf("[Taproot] TapTweak hash...\n");
+    (void)std::printf("[Taproot] TapTweak hash...\n");
 
     auto internal_key_x = hex32(
         "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798");
@@ -279,7 +278,7 @@ static void test_taproot_tweak_hash() {
 }
 
 static void test_taproot_output_key() {
-    std::printf("[Taproot] Output key derivation...\n");
+    (void)std::printf("[Taproot] Output key derivation...\n");
 
     auto sk = Scalar::from_hex(
         "0000000000000000000000000000000000000000000000000000000000000001");
@@ -293,7 +292,7 @@ static void test_taproot_output_key() {
 }
 
 static void test_taproot_privkey_tweak() {
-    std::printf("[Taproot] Private key tweaking...\n");
+    (void)std::printf("[Taproot] Private key tweaking...\n");
 
     auto sk = Scalar::from_hex(
         "0000000000000000000000000000000000000000000000000000000000000001");
@@ -313,7 +312,7 @@ static void test_taproot_privkey_tweak() {
 }
 
 static void test_taproot_commitment_verify() {
-    std::printf("[Taproot] Commitment verification...\n");
+    (void)std::printf("[Taproot] Commitment verification...\n");
 
     auto sk = Scalar::from_hex(
         "0000000000000000000000000000000000000000000000000000000000000002");
@@ -332,7 +331,7 @@ static void test_taproot_commitment_verify() {
 }
 
 static void test_taproot_leaf_and_branch() {
-    std::printf("[Taproot] Leaf and branch hashes...\n");
+    (void)std::printf("[Taproot] Leaf and branch hashes...\n");
 
     // Simple script
     uint8_t script[] = {0xAC}; // OP_CHECKSIG
@@ -357,7 +356,7 @@ static void test_taproot_leaf_and_branch() {
 }
 
 static void test_taproot_merkle_tree() {
-    std::printf("[Taproot] Merkle tree construction...\n");
+    (void)std::printf("[Taproot] Merkle tree construction...\n");
 
     uint8_t s1[] = {0xAC};
     uint8_t s2[] = {0xAD};
@@ -382,7 +381,7 @@ static void test_taproot_merkle_tree() {
 }
 
 static void test_taproot_merkle_proof() {
-    std::printf("[Taproot] Merkle proof verification...\n");
+    (void)std::printf("[Taproot] Merkle proof verification...\n");
 
     uint8_t s1[] = {0xAC};
     uint8_t s2[] = {0xAD};
@@ -397,7 +396,7 @@ static void test_taproot_merkle_proof() {
 }
 
 static void test_taproot_full_flow() {
-    std::printf("[Taproot] Full flow: key-path + script-path...\n");
+    (void)std::printf("[Taproot] Full flow: key-path + script-path...\n");
 
     // Internal key
     auto sk = Scalar::from_hex(
@@ -436,7 +435,7 @@ static void test_taproot_full_flow() {
 // ===============================================================================
 
 static void test_ct_equal() {
-    std::printf("[CT Utils] Constant-time equality...\n");
+    (void)std::printf("[CT Utils] Constant-time equality...\n");
 
     auto a = hex32("0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF");
     auto b = a;
@@ -447,7 +446,7 @@ static void test_ct_equal() {
 }
 
 static void test_ct_is_zero() {
-    std::printf("[CT Utils] Constant-time zero check...\n");
+    (void)std::printf("[CT Utils] Constant-time zero check...\n");
 
     std::array<uint8_t, 32> const zeros{};
     auto nonzero = hex32("0000000000000000000000000000000000000000000000000000000000000001");
@@ -457,7 +456,7 @@ static void test_ct_is_zero() {
 }
 
 static void test_ct_compare() {
-    std::printf("[CT Utils] Constant-time compare...\n");
+    (void)std::printf("[CT Utils] Constant-time compare...\n");
 
     auto a = hex32("0000000000000000000000000000000000000000000000000000000000000001");
     auto b = hex32("0000000000000000000000000000000000000000000000000000000000000002");
@@ -469,7 +468,7 @@ static void test_ct_compare() {
 }
 
 static void test_ct_memzero() {
-    std::printf("[CT Utils] Secure memory zeroing...\n");
+    (void)std::printf("[CT Utils] Secure memory zeroing...\n");
 
     std::array<uint8_t, 32> data;
     std::memset(data.data(), 0xFF, 32);
@@ -479,7 +478,7 @@ static void test_ct_memzero() {
 }
 
 static void test_ct_conditional_ops() {
-    std::printf("[CT Utils] Conditional copy and swap...\n");
+    (void)std::printf("[CT Utils] Conditional copy and swap...\n");
 
     auto a = hex32("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
     auto b = hex32("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB");
@@ -510,7 +509,7 @@ static void test_ct_conditional_ops() {
 // ===============================================================================
 
 static void test_wycheproof_ecdsa_edge_cases() {
-    std::printf("[Wycheproof] ECDSA edge cases...\n");
+    (void)std::printf("[Wycheproof] ECDSA edge cases...\n");
 
     // 1. Signature with s = 1 (minimal s)
     {
@@ -597,7 +596,7 @@ static void test_wycheproof_ecdsa_edge_cases() {
 }
 
 static void test_wycheproof_schnorr_edge_cases() {
-    std::printf("[Wycheproof] Schnorr (BIP-340) edge cases...\n");
+    (void)std::printf("[Wycheproof] Schnorr (BIP-340) edge cases...\n");
 
     // 1. Normal sign/verify
     {
@@ -640,7 +639,7 @@ static void test_wycheproof_schnorr_edge_cases() {
 }
 
 static void test_wycheproof_recovery_edge_cases() {
-    std::printf("[Wycheproof] Recovery edge cases...\n");
+    (void)std::printf("[Wycheproof] Recovery edge cases...\n");
 
     // 1. Recovery round-trip with various message hashes
     const char* const messages[] = {
@@ -678,9 +677,9 @@ static void test_wycheproof_recovery_edge_cases() {
 // ===============================================================================
 
 int test_ecdh_recovery_taproot_run() {
-    std::printf("===============================================================\n");
-    std::printf("  UltrafastSecp256k1 -- v3.2.0 Feature Tests\n");
-    std::printf("===============================================================\n\n");
+    (void)std::printf("===============================================================\n");
+    (void)std::printf("  UltrafastSecp256k1 -- v3.2.0 Feature Tests\n");
+    (void)std::printf("===============================================================\n\n");
 
     // ECDH
     test_ecdh_basic();
@@ -689,7 +688,7 @@ int test_ecdh_recovery_taproot_run() {
     test_ecdh_zero_key();
     test_ecdh_infinity();
 
-    std::printf("\n");
+    (void)std::printf("\n");
 
     // Recovery
     test_recovery_basic();
@@ -698,7 +697,7 @@ int test_ecdh_recovery_taproot_run() {
     test_recovery_wrong_recid();
     test_recovery_invalid_sig();
 
-    std::printf("\n");
+    (void)std::printf("\n");
 
     // Taproot
     test_taproot_tweak_hash();
@@ -710,7 +709,7 @@ int test_ecdh_recovery_taproot_run() {
     test_taproot_merkle_proof();
     test_taproot_full_flow();
 
-    std::printf("\n");
+    (void)std::printf("\n");
 
     // CT Utils
     test_ct_equal();
@@ -719,17 +718,17 @@ int test_ecdh_recovery_taproot_run() {
     test_ct_memzero();
     test_ct_conditional_ops();
 
-    std::printf("\n");
+    (void)std::printf("\n");
 
     // Wycheproof Edge Cases
     test_wycheproof_ecdsa_edge_cases();
     test_wycheproof_schnorr_edge_cases();
     test_wycheproof_recovery_edge_cases();
 
-    std::printf("\n===============================================================\n");
-    std::printf("  Results: %d passed, %d failed (total %d)\n",
+    (void)std::printf("\n===============================================================\n");
+    (void)std::printf("  Results: %d passed, %d failed (total %d)\n",
                 g_pass, g_fail, g_pass + g_fail);
-    std::printf("===============================================================\n");
+    (void)std::printf("===============================================================\n");
 
     return g_fail > 0 ? 1 : 0;
 }

--- a/cpu/tests/test_field_26.cpp
+++ b/cpu/tests/test_field_26.cpp
@@ -23,7 +23,7 @@ int g_tests_failed = 0;
 
 #define CHECK(cond, msg) do {                                      \
     if (!(cond)) {                                                 \
-        std::printf("  FAIL: %s (line %d)\n", msg, __LINE__);     \
+        (void)std::printf("  FAIL: %s (line %d)\n", msg, __LINE__);     \
         g_tests_failed++;                                          \
     } else {                                                       \
         g_tests_passed++;                                          \
@@ -70,7 +70,7 @@ constexpr int NUM_VECTORS = sizeof(VECTORS) / sizeof(VECTORS[0]);
 // ===========================================================================
 
 void test_conversion_roundtrip() {
-    std::printf("-- Conversion Roundtrip (4x64 -> 10x26 -> 4x64) --\n");
+    (void)std::printf("-- Conversion Roundtrip (4x64 -> 10x26 -> 4x64) --\n");
     for (int i = 0; i < NUM_VECTORS; ++i) {
         FieldElement const fe = FieldElement::from_limbs(VECTORS[i].limbs);
         FieldElement26 const fe26 = FieldElement26::from_fe(fe);
@@ -80,7 +80,7 @@ void test_conversion_roundtrip() {
 }
 
 void test_zero_one() {
-    std::printf("-- Zero / One --\n");
+    (void)std::printf("-- Zero / One --\n");
     FieldElement26 const z = FieldElement26::zero();
     FieldElement26 const o = FieldElement26::one();
     CHECK(fe26_equals_fe64(z, FieldElement::zero()), "zero matches");
@@ -90,7 +90,7 @@ void test_zero_one() {
 }
 
 void test_addition() {
-    std::printf("-- Addition --\n");
+    (void)std::printf("-- Addition --\n");
     for (int i = 0; i < NUM_VECTORS; ++i) {
         for (int j = 0; j < NUM_VECTORS; ++j) {
             FieldElement const a = FieldElement::from_limbs(VECTORS[i].limbs);
@@ -104,7 +104,7 @@ void test_addition() {
             bool const ok = fe26_equals_fe64(sum26, sum64);
             if (!ok) {
                 char buf[128];
-                std::snprintf(buf, sizeof(buf), "add(%s, %s)",
+                (void)std::snprintf(buf, sizeof(buf), "add(%s, %s)",
                              VECTORS[i].name, VECTORS[j].name);
                 CHECK(false, buf);
             } else {
@@ -112,11 +112,11 @@ void test_addition() {
             }
         }
     }
-    std::printf("  %d addition pairs tested\n", NUM_VECTORS * NUM_VECTORS);
+    (void)std::printf("  %d addition pairs tested\n", NUM_VECTORS * NUM_VECTORS);
 }
 
 void test_lazy_chain() {
-    std::printf("-- Lazy Addition Chain (accumulate without normalize) --\n");
+    (void)std::printf("-- Lazy Addition Chain (accumulate without normalize) --\n");
 
     FieldElement const a = FieldElement::from_limbs(VECTORS[7].limbs);  // Gx
     FieldElement const b = FieldElement::from_limbs(VECTORS[8].limbs);  // Gy
@@ -144,7 +144,7 @@ void test_lazy_chain() {
 }
 
 void test_negate() {
-    std::printf("-- Negate --\n");
+    (void)std::printf("-- Negate --\n");
     for (int i = 0; i < NUM_VECTORS; ++i) {
         FieldElement const fe = FieldElement::from_limbs(VECTORS[i].limbs);
         FieldElement const neg64 = FieldElement::zero() - fe;
@@ -155,7 +155,7 @@ void test_negate() {
         bool const ok = fe26_equals_fe64(neg26, neg64);
         if (!ok) {
             char buf[128];
-            std::snprintf(buf, sizeof(buf), "negate(%s)", VECTORS[i].name);
+            (void)std::snprintf(buf, sizeof(buf), "negate(%s)", VECTORS[i].name);
             CHECK(false, buf);
         } else {
             g_tests_passed++;
@@ -164,7 +164,7 @@ void test_negate() {
 }
 
 void test_multiplication() {
-    std::printf("-- Multiplication --\n");
+    (void)std::printf("-- Multiplication --\n");
     for (int i = 0; i < NUM_VECTORS; ++i) {
         for (int j = 0; j < NUM_VECTORS; ++j) {
             FieldElement const a = FieldElement::from_limbs(VECTORS[i].limbs);
@@ -178,7 +178,7 @@ void test_multiplication() {
             bool const ok = fe26_equals_fe64(prod26, prod64);
             if (!ok) {
                 char buf[128];
-                std::snprintf(buf, sizeof(buf), "mul(%s, %s)",
+                (void)std::snprintf(buf, sizeof(buf), "mul(%s, %s)",
                              VECTORS[i].name, VECTORS[j].name);
                 CHECK(false, buf);
             } else {
@@ -186,11 +186,11 @@ void test_multiplication() {
             }
         }
     }
-    std::printf("  %d multiplication pairs tested\n", NUM_VECTORS * NUM_VECTORS);
+    (void)std::printf("  %d multiplication pairs tested\n", NUM_VECTORS * NUM_VECTORS);
 }
 
 void test_squaring() {
-    std::printf("-- Squaring --\n");
+    (void)std::printf("-- Squaring --\n");
     for (int i = 0; i < NUM_VECTORS; ++i) {
         FieldElement const a = FieldElement::from_limbs(VECTORS[i].limbs);
         FieldElement const sq64 = a.square();
@@ -201,7 +201,7 @@ void test_squaring() {
         bool const ok = fe26_equals_fe64(sq26, sq64);
         if (!ok) {
             char buf[128];
-            std::snprintf(buf, sizeof(buf), "square(%s)", VECTORS[i].name);
+            (void)std::snprintf(buf, sizeof(buf), "square(%s)", VECTORS[i].name);
             CHECK(false, buf);
         } else {
             g_tests_passed++;
@@ -214,7 +214,7 @@ void test_squaring() {
 }
 
 void test_mul_chain() {
-    std::printf("-- Multiplication Chain (repeated squaring) --\n");
+    (void)std::printf("-- Multiplication Chain (repeated squaring) --\n");
     FieldElement fe = FieldElement::from_limbs(VECTORS[7].limbs);  // Gx
     FieldElement26 fe26 = FieldElement26::from_fe(fe);
 
@@ -234,7 +234,7 @@ void test_mul_chain() {
 }
 
 void test_mixed_operations() {
-    std::printf("-- Mixed Operations (add + mul + square chains) --\n");
+    (void)std::printf("-- Mixed Operations (add + mul + square chains) --\n");
     FieldElement const a = FieldElement::from_limbs(VECTORS[7].limbs);  // Gx
     FieldElement const b = FieldElement::from_limbs(VECTORS[8].limbs);  // Gy
     FieldElement26 const a26 = FieldElement26::from_fe(a);
@@ -266,7 +266,7 @@ void test_mixed_operations() {
 }
 
 void test_half() {
-    std::printf("-- Half --\n");
+    (void)std::printf("-- Half --\n");
     for (int i = 0; i < NUM_VECTORS; ++i) {
         FieldElement const a = FieldElement::from_limbs(VECTORS[i].limbs);
         FieldElement26 const a26 = FieldElement26::from_fe(a);
@@ -280,7 +280,7 @@ void test_half() {
 }
 
 void test_normalize_edge() {
-    std::printf("-- Normalization Edge Cases --\n");
+    (void)std::printf("-- Normalization Edge Cases --\n");
     using namespace fe26_constants;
 
     // Test value = p (should normalize to 0)
@@ -310,7 +310,7 @@ void test_normalize_edge() {
 }
 
 void test_commutativity_associativity() {
-    std::printf("-- Commutativity & Associativity --\n");
+    (void)std::printf("-- Commutativity & Associativity --\n");
     FieldElement26 const a = FieldElement26::from_fe(FieldElement::from_limbs(VECTORS[7].limbs));
     FieldElement26 const b = FieldElement26::from_fe(FieldElement::from_limbs(VECTORS[8].limbs));
     FieldElement26 const c = FieldElement26::from_fe(FieldElement::from_limbs(VECTORS[9].limbs));
@@ -339,7 +339,7 @@ void test_commutativity_associativity() {
 }
 
 void test_mul_after_lazy_add() {
-    std::printf("-- Mul After Lazy Additions --\n");
+    (void)std::printf("-- Mul After Lazy Additions --\n");
     // Test that mul works correctly on inputs with high magnitude
     // (limb values > 26 bits due to lazy additions)
     FieldElement const a = FieldElement::from_limbs(VECTORS[7].limbs);
@@ -381,7 +381,7 @@ int main() {
 #else
 int test_field_26_main() {
 #endif
-    std::printf("\n=== FieldElement26 (10x26 Lazy-Reduction) Tests ===\n\n");
+    (void)std::printf("\n=== FieldElement26 (10x26 Lazy-Reduction) Tests ===\n\n");
 
     test_conversion_roundtrip();
     test_zero_one();
@@ -397,7 +397,7 @@ int test_field_26_main() {
     test_commutativity_associativity();
     test_mul_after_lazy_add();
 
-    std::printf("\n=== Results: %d passed, %d failed ===\n",
+    (void)std::printf("\n=== Results: %d passed, %d failed ===\n",
                g_tests_passed, g_tests_failed);
 
     return g_tests_failed > 0 ? 1 : 0;

--- a/cpu/tests/test_field_52.cpp
+++ b/cpu/tests/test_field_52.cpp
@@ -23,7 +23,7 @@ int g_tests_failed = 0;
 
 #define CHECK(cond, msg) do {                                      \
     if (!(cond)) {                                                 \
-        std::printf("  FAIL: %s (line %d)\n", msg, __LINE__);     \
+        (void)std::printf("  FAIL: %s (line %d)\n", msg, __LINE__);     \
         g_tests_failed++;                                          \
     } else {                                                       \
         g_tests_passed++;                                          \
@@ -70,7 +70,7 @@ constexpr int NUM_VECTORS = sizeof(VECTORS) / sizeof(VECTORS[0]);
 // ===========================================================================
 
 void test_conversion_roundtrip() {
-    std::printf("-- Conversion Roundtrip (4x64 -> 5x52 -> 4x64) --\n");
+    (void)std::printf("-- Conversion Roundtrip (4x64 -> 5x52 -> 4x64) --\n");
     for (int i = 0; i < NUM_VECTORS; ++i) {
         FieldElement const fe = FieldElement::from_limbs(VECTORS[i].limbs);
         FieldElement52 const fe52 = FieldElement52::from_fe(fe);
@@ -80,7 +80,7 @@ void test_conversion_roundtrip() {
 }
 
 void test_zero_one() {
-    std::printf("-- Zero / One --\n");
+    (void)std::printf("-- Zero / One --\n");
     FieldElement52 const z = FieldElement52::zero();
     FieldElement52 const o = FieldElement52::one();
     CHECK(fe52_equals_fe64(z, FieldElement::zero()), "zero matches");
@@ -90,7 +90,7 @@ void test_zero_one() {
 }
 
 void test_addition() {
-    std::printf("-- Addition --\n");
+    (void)std::printf("-- Addition --\n");
     for (int i = 0; i < NUM_VECTORS; ++i) {
         for (int j = 0; j < NUM_VECTORS; ++j) {
             FieldElement const a = FieldElement::from_limbs(VECTORS[i].limbs);
@@ -105,7 +105,7 @@ void test_addition() {
             bool const ok = fe52_equals_fe64(sum52, sum64);
             if (!ok) {
                 char buf[128];
-                std::snprintf(buf, sizeof(buf), "add(%s, %s)",
+                (void)std::snprintf(buf, sizeof(buf), "add(%s, %s)",
                              VECTORS[i].name, VECTORS[j].name);
                 CHECK(false, buf);
             } else {
@@ -113,11 +113,11 @@ void test_addition() {
             }
         }
     }
-    std::printf("  %d addition pairs tested\n", NUM_VECTORS * NUM_VECTORS);
+    (void)std::printf("  %d addition pairs tested\n", NUM_VECTORS * NUM_VECTORS);
 }
 
 void test_lazy_chain() {
-    std::printf("-- Lazy Addition Chain (accumulate without normalize) --\n");
+    (void)std::printf("-- Lazy Addition Chain (accumulate without normalize) --\n");
 
     FieldElement const a = FieldElement::from_limbs(VECTORS[7].limbs);  // Gx
     FieldElement const b = FieldElement::from_limbs(VECTORS[8].limbs);  // Gy
@@ -144,7 +144,7 @@ void test_lazy_chain() {
 }
 
 void test_negate() {
-    std::printf("-- Negate --\n");
+    (void)std::printf("-- Negate --\n");
     for (int i = 0; i < NUM_VECTORS; ++i) {
         FieldElement const fe = FieldElement::from_limbs(VECTORS[i].limbs);
         FieldElement const neg64 = FieldElement::zero() - fe;
@@ -155,7 +155,7 @@ void test_negate() {
         bool const ok = fe52_equals_fe64(neg52, neg64);
         if (!ok) {
             char buf[128];
-            std::snprintf(buf, sizeof(buf), "negate(%s)", VECTORS[i].name);
+            (void)std::snprintf(buf, sizeof(buf), "negate(%s)", VECTORS[i].name);
             CHECK(false, buf);
         } else {
             g_tests_passed++;
@@ -164,7 +164,7 @@ void test_negate() {
 }
 
 void test_multiplication() {
-    std::printf("-- Multiplication --\n");
+    (void)std::printf("-- Multiplication --\n");
     for (int i = 0; i < NUM_VECTORS; ++i) {
         for (int j = 0; j < NUM_VECTORS; ++j) {
             FieldElement const a = FieldElement::from_limbs(VECTORS[i].limbs);
@@ -178,7 +178,7 @@ void test_multiplication() {
             bool const ok = fe52_equals_fe64(prod52, prod64);
             if (!ok) {
                 char buf[128];
-                std::snprintf(buf, sizeof(buf), "mul(%s, %s)",
+                (void)std::snprintf(buf, sizeof(buf), "mul(%s, %s)",
                              VECTORS[i].name, VECTORS[j].name);
                 CHECK(false, buf);
             } else {
@@ -186,11 +186,11 @@ void test_multiplication() {
             }
         }
     }
-    std::printf("  %d multiplication pairs tested\n", NUM_VECTORS * NUM_VECTORS);
+    (void)std::printf("  %d multiplication pairs tested\n", NUM_VECTORS * NUM_VECTORS);
 }
 
 void test_squaring() {
-    std::printf("-- Squaring --\n");
+    (void)std::printf("-- Squaring --\n");
     for (int i = 0; i < NUM_VECTORS; ++i) {
         FieldElement const a = FieldElement::from_limbs(VECTORS[i].limbs);
         FieldElement const sq64 = a.square();
@@ -201,7 +201,7 @@ void test_squaring() {
         bool const ok = fe52_equals_fe64(sq52, sq64);
         if (!ok) {
             char buf[128];
-            std::snprintf(buf, sizeof(buf), "square(%s)", VECTORS[i].name);
+            (void)std::snprintf(buf, sizeof(buf), "square(%s)", VECTORS[i].name);
             CHECK(false, buf);
         } else {
             g_tests_passed++;
@@ -214,7 +214,7 @@ void test_squaring() {
 }
 
 void test_mul_chain() {
-    std::printf("-- Multiplication Chain (repeated squaring) --\n");
+    (void)std::printf("-- Multiplication Chain (repeated squaring) --\n");
     FieldElement fe = FieldElement::from_limbs(VECTORS[7].limbs);  // Gx
     FieldElement52 fe52 = FieldElement52::from_fe(fe);
 
@@ -234,7 +234,7 @@ void test_mul_chain() {
 }
 
 void test_mixed_operations() {
-    std::printf("-- Mixed Operations (add + mul + square chains) --\n");
+    (void)std::printf("-- Mixed Operations (add + mul + square chains) --\n");
     FieldElement const a = FieldElement::from_limbs(VECTORS[7].limbs);  // Gx
     FieldElement const b = FieldElement::from_limbs(VECTORS[8].limbs);  // Gy
     FieldElement52 const a52 = FieldElement52::from_fe(a);
@@ -267,7 +267,7 @@ void test_mixed_operations() {
 }
 
 void test_half() {
-    std::printf("-- Half --\n");
+    (void)std::printf("-- Half --\n");
     for (int i = 0; i < NUM_VECTORS; ++i) {
         FieldElement const a = FieldElement::from_limbs(VECTORS[i].limbs);
         FieldElement52 const a52 = FieldElement52::from_fe(a);
@@ -281,7 +281,7 @@ void test_half() {
 }
 
 void test_normalize_edge() {
-    std::printf("-- Normalization Edge Cases --\n");
+    (void)std::printf("-- Normalization Edge Cases --\n");
 
     // Test value = p (should normalize to 0)
     FieldElement52 p_val;
@@ -316,7 +316,7 @@ void test_normalize_edge() {
 }
 
 void test_commutativity_associativity() {
-    std::printf("-- Commutativity & Associativity --\n");
+    (void)std::printf("-- Commutativity & Associativity --\n");
     FieldElement52 const a = FieldElement52::from_fe(FieldElement::from_limbs(VECTORS[7].limbs));
     FieldElement52 const b = FieldElement52::from_fe(FieldElement::from_limbs(VECTORS[8].limbs));
     FieldElement52 const c = FieldElement52::from_fe(FieldElement::from_limbs(VECTORS[9].limbs));
@@ -351,7 +351,7 @@ int main() {
 #else
 int test_field_52_main() {
 #endif
-    std::printf("\n=== FieldElement52 (5x52 Lazy-Reduction) Tests ===\n\n");
+    (void)std::printf("\n=== FieldElement52 (5x52 Lazy-Reduction) Tests ===\n\n");
 
     test_conversion_roundtrip();
     test_zero_one();
@@ -366,7 +366,7 @@ int test_field_52_main() {
     test_normalize_edge();
     test_commutativity_associativity();
 
-    std::printf("\n=== Results: %d passed, %d failed ===\n",
+    (void)std::printf("\n=== Results: %d passed, %d failed ===\n",
                g_tests_passed, g_tests_failed);
 
     return g_tests_failed > 0 ? 1 : 0;

--- a/cpu/tests/test_hash_accel.cpp
+++ b/cpu/tests/test_hash_accel.cpp
@@ -23,32 +23,32 @@ static void check(bool cond, const char* name) {
         ++g_pass;
     } else {
         ++g_fail;
-        std::printf("  FAIL: %s\n", name);
+        (void)std::printf("  FAIL: %s\n", name);
     }
 }
 
 [[maybe_unused]] static void print_hex(const std::uint8_t* data, std::size_t len) {
     for (std::size_t i = 0; i < len; ++i) {
-        std::printf("%02x", data[i]);
+        (void)std::printf("%02x", data[i]);
 }
 }
 
 // -- Test 1: Feature detection ------------------------------------------------
 
 static void test_feature_detection() {
-    std::printf("[HashAccel] Feature detection...\n");
+    (void)std::printf("[HashAccel] Feature detection...\n");
     auto tier = hash::detect_hash_tier();
-    std::printf("  Hash tier: %s\n", hash::hash_tier_name(tier));
-    std::printf("  SHA-NI:    %s\n", hash::sha_ni_available() ? "yes" : "no");
-    std::printf("  AVX2:      %s\n", hash::avx2_available() ? "yes" : "no");
-    std::printf("  AVX-512:   %s\n", hash::avx512_available() ? "yes" : "no");
+    (void)std::printf("  Hash tier: %s\n", hash::hash_tier_name(tier));
+    (void)std::printf("  SHA-NI:    %s\n", hash::sha_ni_available() ? "yes" : "no");
+    (void)std::printf("  AVX2:      %s\n", hash::avx2_available() ? "yes" : "no");
+    (void)std::printf("  AVX-512:   %s\n", hash::avx512_available() ? "yes" : "no");
     check(true, "feature detection completed");
 }
 
 // -- Test 2: SHA-256 known vectors --------------------------------------------
 
 static void test_sha256_vectors() {
-    std::printf("[HashAccel] SHA-256 known vectors...\n");
+    (void)std::printf("[HashAccel] SHA-256 known vectors...\n");
 
     // NIST vector: SHA256("abc")
     {
@@ -78,7 +78,7 @@ static void test_sha256_vectors() {
 // -- Test 3: sha256_33 vs reference -------------------------------------------
 
 static void test_sha256_33_correctness() {
-    std::printf("[HashAccel] sha256_33 correctness...\n");
+    (void)std::printf("[HashAccel] sha256_33 correctness...\n");
 
     // Generate a compressed pubkey from 1*G
     auto gen = fast::Point::generator();
@@ -105,7 +105,7 @@ static void test_sha256_33_correctness() {
         auto r = SHA256::hash(comp.data(), 33);
         hash::sha256_33(comp.data(), accel);
         char label[80];
-        std::snprintf(label, sizeof(label), "sha256_33(%dG) correct", i + 1);
+        (void)std::snprintf(label, sizeof(label), "sha256_33(%dG) correct", i + 1);
         check(std::memcmp(r.data(), accel, 32) == 0, label);
         pt.next_inplace();
     }
@@ -114,7 +114,7 @@ static void test_sha256_33_correctness() {
 // -- Test 4: sha256_32 correctness --------------------------------------------
 
 static void test_sha256_32_correctness() {
-    std::printf("[HashAccel] sha256_32 correctness...\n");
+    (void)std::printf("[HashAccel] sha256_32 correctness...\n");
 
     std::uint8_t data[32];
     for (int i = 0; i < 32; ++i) data[i] = static_cast<std::uint8_t>(i);
@@ -129,7 +129,7 @@ static void test_sha256_32_correctness() {
 // -- Test 5: RIPEMD-160 known vectors -----------------------------------------
 
 static void test_ripemd160_vectors() {
-    std::printf("[HashAccel] RIPEMD-160 known vectors...\n");
+    (void)std::printf("[HashAccel] RIPEMD-160 known vectors...\n");
 
     // RIPEMD-160("abc") = 8eb208f7e05d987a9b044a8e98c6b087f15a0bfc
     {
@@ -169,7 +169,7 @@ static void test_ripemd160_vectors() {
 // -- Test 6: ripemd160_32 correctness -----------------------------------------
 
 static void test_ripemd160_32_correctness() {
-    std::printf("[HashAccel] ripemd160_32 correctness...\n");
+    (void)std::printf("[HashAccel] ripemd160_32 correctness...\n");
 
     // Hash 32 zero bytes via general API
     std::uint8_t zeros[32] = {};
@@ -191,7 +191,7 @@ static void test_ripemd160_32_correctness() {
 // -- Test 7: Hash160 pipeline -------------------------------------------------
 
 static void test_hash160_pipeline() {
-    std::printf("[HashAccel] Hash160 pipeline correctness...\n");
+    (void)std::printf("[HashAccel] Hash160 pipeline correctness...\n");
 
     // Compute Hash160 of 1*G compressed pubkey via two methods:
     // Method 1: hash::hash160_33
@@ -223,7 +223,7 @@ static void test_hash160_pipeline() {
         hash::hash160_33(c.data(), accel);
         
         char label[80];
-        std::snprintf(label, sizeof(label), "hash160_33(%dG) correct", i + 1);
+        (void)std::snprintf(label, sizeof(label), "hash160_33(%dG) correct", i + 1);
         check(std::memcmp(ref_rmd.data(), accel, 20) == 0, label);
         pt.next_inplace();
     }
@@ -232,7 +232,7 @@ static void test_hash160_pipeline() {
 // -- Test 8: Batch operations -------------------------------------------------
 
 static void test_batch_ops() {
-    std::printf("[HashAccel] Batch operations...\n");
+    (void)std::printf("[HashAccel] Batch operations...\n");
 
     constexpr std::size_t COUNT = 256;
 
@@ -253,7 +253,7 @@ static void test_batch_ops() {
     for (std::size_t i = 0; i < COUNT; ++i) {
         auto ref = SHA256::hash(pubkeys.data() + i * 33, 33);
         char label[80];
-        std::snprintf(label, sizeof(label), "sha256_33_batch[%zu]", i);
+        (void)std::snprintf(label, sizeof(label), "sha256_33_batch[%zu]", i);
         check(std::memcmp(ref.data(), sha_results.data() + i * 32, 32) == 0, label);
     }
 
@@ -268,7 +268,7 @@ static void test_batch_ops() {
         auto ref_sha = SHA256::hash(comp.data(), 33);
         auto ref_rmd = hash::ripemd160(ref_sha.data(), 32);
         char label[80];
-        std::snprintf(label, sizeof(label), "hash160_33_batch[%zu]", i);
+        (void)std::snprintf(label, sizeof(label), "hash160_33_batch[%zu]", i);
         check(std::memcmp(ref_rmd.data(), h160_results.data() + i * 20, 20) == 0, label);
         pt.next_inplace();
     }
@@ -277,11 +277,11 @@ static void test_batch_ops() {
 // -- Test 9: SHA-NI vs Scalar cross-check -------------------------------------
 
 static void test_shani_vs_scalar() {
-    std::printf("[HashAccel] SHA-NI vs Scalar cross-check...\n");
+    (void)std::printf("[HashAccel] SHA-NI vs Scalar cross-check...\n");
 
 #ifdef SECP256K1_X86_TARGET
     if (!hash::sha_ni_available()) {
-        std::printf("  SHA-NI not available, skipping\n");
+        (void)std::printf("  SHA-NI not available, skipping\n");
         check(true, "SHA-NI not available (skip)");
         return;
     }
@@ -297,13 +297,13 @@ static void test_shani_vs_scalar() {
         hash::shani::sha256_33(comp.data(), shani_out);
 
         char label[80];
-        std::snprintf(label, sizeof(label), "SHA-NI == Scalar for %dG", i + 1);
+        (void)std::snprintf(label, sizeof(label), "SHA-NI == Scalar for %dG", i + 1);
         check(std::memcmp(scalar_out, shani_out, 32) == 0, label);
 
         pt.next_inplace();
     }
 #else
-    std::printf("  Not x86, skipping SHA-NI test\n");
+    (void)std::printf("  Not x86, skipping SHA-NI test\n");
     check(true, "Not x86 (skip)");
 #endif
 }
@@ -311,7 +311,7 @@ static void test_shani_vs_scalar() {
 // -- Test 10: Benchmark -------------------------------------------------------
 
 static void test_benchmark() {
-    std::printf("[HashAccel] Benchmark...\n");
+    (void)std::printf("[HashAccel] Benchmark...\n");
 
     // Prepare a typical compressed pubkey
     auto gen = fast::Point::generator();
@@ -328,7 +328,7 @@ static void test_benchmark() {
         }
         auto t1 = std::chrono::high_resolution_clock::now();
         double const ns = static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
-        std::printf("  Scalar SHA256_33:  %.1f ns/call\n", ns / ITERS);
+        (void)std::printf("  Scalar SHA256_33:  %.1f ns/call\n", ns / ITERS);
     }
 
     // Auto-dispatch SHA256_33
@@ -339,7 +339,7 @@ static void test_benchmark() {
         }
         auto t1 = std::chrono::high_resolution_clock::now();
         double const ns = static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
-        std::printf("  Auto   SHA256_33:  %.1f ns/call (%s)\n", ns / ITERS, hash::hash_tier_name(hash::detect_hash_tier()));
+        (void)std::printf("  Auto   SHA256_33:  %.1f ns/call (%s)\n", ns / ITERS, hash::hash_tier_name(hash::detect_hash_tier()));
     }
 
     // Scalar RIPEMD160_32
@@ -350,7 +350,7 @@ static void test_benchmark() {
         }
         auto t1 = std::chrono::high_resolution_clock::now();
         double const ns = static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
-        std::printf("  Scalar RIPEMD160_32: %.1f ns/call\n", ns / ITERS);
+        (void)std::printf("  Scalar RIPEMD160_32: %.1f ns/call\n", ns / ITERS);
     }
 
     // Hash160_33 (fused SHA256+RIPEMD160)
@@ -361,7 +361,7 @@ static void test_benchmark() {
         }
         auto t1 = std::chrono::high_resolution_clock::now();
         double const ns = static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
-        std::printf("  Auto   Hash160_33: %.1f ns/call\n", ns / ITERS);
+        (void)std::printf("  Auto   Hash160_33: %.1f ns/call\n", ns / ITERS);
     }
 
     // Old SHA256 class (reference baseline)
@@ -373,7 +373,7 @@ static void test_benchmark() {
         }
         auto t1 = std::chrono::high_resolution_clock::now();
         double const ns = static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
-        std::printf("  Old    SHA256::hash: %.1f ns/call (reference)\n", ns / ITERS);
+        (void)std::printf("  Old    SHA256::hash: %.1f ns/call (reference)\n", ns / ITERS);
     }
 
     // Batch Hash160
@@ -399,7 +399,7 @@ static void test_benchmark() {
         auto t1 = std::chrono::high_resolution_clock::now();
         double const total_ns = static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
         double const per_key = total_ns / BATCH_ITERS / BATCH;
-        std::printf("  Batch  Hash160_33 (%zu): %.1f ns/key, %.2f Mkeys/s\n",
+        (void)std::printf("  Batch  Hash160_33 (%zu): %.1f ns/key, %.2f Mkeys/s\n",
                     BATCH, per_key, 1e9 / per_key / 1e6);
     }
 
@@ -409,7 +409,7 @@ static void test_benchmark() {
 // -- Test 11: Double-SHA256 ---------------------------------------------------
 
 static void test_double_sha256() {
-    std::printf("[HashAccel] Double-SHA256...\n");
+    (void)std::printf("[HashAccel] Double-SHA256...\n");
 
     std::uint8_t data[] = {0x01, 0x02, 0x03};
 
@@ -424,7 +424,7 @@ static void test_double_sha256() {
 // -- Entry point --------------------------------------------------------------
 
 int test_hash_accel_run() {
-    std::printf("\n=== Accelerated Hashing Tests ===\n");
+    (void)std::printf("\n=== Accelerated Hashing Tests ===\n");
 
     test_feature_detection();
     test_sha256_vectors();
@@ -438,7 +438,7 @@ int test_hash_accel_run() {
     test_shani_vs_scalar();
     test_benchmark();
 
-    std::printf("\n  Hash accel: %d passed, %d failed\n", g_pass, g_fail);
+    (void)std::printf("\n  Hash accel: %d passed, %d failed\n", g_pass, g_fail);
     return g_fail;
 }
 

--- a/cpu/tests/test_large_scalar_multiplication.cpp
+++ b/cpu/tests/test_large_scalar_multiplication.cpp
@@ -126,7 +126,7 @@ static void test_fast_vs_generic() {
     }
 
     // Random large scalars
-    std::mt19937_64 rng(111);
+    std::mt19937_64 rng(111);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     for (int i = 0; i < 100; i++) {
         std::array<uint64_t, 4> const ls{rng(), rng(), rng(), rng()};
         Scalar const k = Scalar::from_limbs(ls);
@@ -283,7 +283,7 @@ static void test_kq_random() {
     std::cout << "-- Random K*Q = (k1*k2)*G --\n";
 
     Point const G = Point::generator();
-    std::mt19937_64 rng(222);
+    std::mt19937_64 rng(222);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
 
     for (int i = 0; i < 50; i++) {
         std::array<uint8_t, 32> b1{}, b2{};
@@ -321,7 +321,7 @@ static void test_distributive() {
     }
 
     // Random large k
-    std::mt19937_64 rng(333);
+    std::mt19937_64 rng(333);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     for (int i = 0; i < 20; i++) {
         std::array<uint8_t, 32> bk{};
         for (std::size_t j = 0; j < 32; j++) bk[j] = static_cast<uint8_t>(rng());

--- a/cpu/tests/test_mul.cpp
+++ b/cpu/tests/test_mul.cpp
@@ -16,10 +16,12 @@ static int g_pass = 0;
 static int g_fail = 0;
 
 #define CHECK(cond, msg) do { \
-    if (!(cond)) { \
+    if (cond) { \
+        ++g_pass; \
+    } else { \
         std::cerr << "FAIL: " << (msg) << " (" << __FILE__ << ":" << __LINE__ << ")\n"; \
         ++g_fail; \
-    } else { ++g_pass; } \
+    } \
 } while(0)
 
 // ================================================================
@@ -65,7 +67,7 @@ static void test_field_mul() {
     CHECK((a * b) * c == a * (b * c), "(a*b)*c = a*(b*c)");
 
     // Distributivity random stress: a*(b+c) = a*b + a*c
-    std::mt19937_64 rng(101);
+    std::mt19937_64 rng(101);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     for (int i = 0; i < 500; i++) {
         std::array<uint64_t, 4> const la{rng(), rng(), rng(), rng()};
         std::array<uint64_t, 4> const lb{rng(), rng(), rng(), rng()};
@@ -96,7 +98,7 @@ static void test_field_square() {
     CHECK(o2 == o, "1^2 = 1");
 
     // Random: sq(a) == a*a
-    std::mt19937_64 rng(202);
+    std::mt19937_64 rng(202);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     for (int i = 0; i < 500; i++) {
         std::array<uint64_t, 4> const la{rng(), rng(), rng(), rng()};
         FieldElement const fa = FieldElement::from_limbs(la);
@@ -139,7 +141,7 @@ static void test_field_add_sub() {
     CHECK(sum == mul2, "big+big == big*2 (modular wrap)");
 
     // Random stress: (a-b)+b = a
-    std::mt19937_64 rng(303);
+    std::mt19937_64 rng(303);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     for (int i = 0; i < 500; i++) {
         std::array<uint64_t, 4> const la{rng(), rng(), rng(), rng()};
         std::array<uint64_t, 4> const lb{rng(), rng(), rng(), rng()};
@@ -239,7 +241,7 @@ static void test_scalar_arithmetic() {
     CHECK(nm1 + one == zero, "(n-1)+1 = 0");
 
     // Distributive: a*(b+c) = a*b + a*c  (random)
-    std::mt19937_64 rng(404);
+    std::mt19937_64 rng(404);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     for (int i = 0; i < 1000; i++) {
         std::array<uint8_t, 32> ba{}, bb{}, bc{};
         for (std::size_t j = 0; j < 32; j++) {
@@ -296,7 +298,7 @@ static void test_scalar_encoding() {
     CHECK(naf1.size() == 1 && naf1[0] == 1, "NAF(1) = {1}");
 
     // NAF adjacency property: no two consecutive non-zero digits
-    std::mt19937_64 rng(505);
+    std::mt19937_64 rng(505);  // NOLINT(cert-msc32-c,cert-msc51-cpp)
     for (int i = 0; i < 200; i++) {
         std::array<uint8_t, 32> ba{};
         for (std::size_t j = 0; j < 32; j++) ba[j] = static_cast<uint8_t>(rng());

--- a/cpu/tests/test_rfc6979_vectors.cpp
+++ b/cpu/tests/test_rfc6979_vectors.cpp
@@ -33,11 +33,11 @@ static int tests_passed = 0;
 // -- Hex helpers (allocation-free) -------------------------------------------
 
 static void print_hex(const char* label, const uint8_t* data, size_t len) {
-    printf("    %s: ", label);
+    (void)printf("    %s: ", label);
     for (size_t i = 0; i < len; ++i) {
-        printf("%02x", data[i]);
+        (void)printf("%02x", data[i]);
 }
-    printf("\n");
+    (void)printf("\n");
 }
 
 // -- SHA-256 of ASCII string --------------------------------------------------
@@ -56,7 +56,7 @@ static bool scalar_eq_hex(const Scalar& got, const char* expected_hex,
     // Diagnostic on mismatch
     auto got_bytes = got.to_bytes();
     auto exp_bytes = expected.to_bytes();
-    printf("    MISMATCH in %s:\n", label);
+    (void)printf("    MISMATCH in %s:\n", label);
     print_hex("expected", exp_bytes.data(), 32);
     print_hex("got     ", got_bytes.data(), 32);
     return false;
@@ -70,7 +70,7 @@ static bool scalar_eq_hex(const Scalar& got, const char* expected_hex,
 // ============================================================================
 
 static void test_rfc6979_nonce_vectors() {
-    printf("\n--- RFC 6979 Nonce Generation (secp256k1 + SHA-256) ---\n");
+    (void)printf("\n--- RFC 6979 Nonce Generation (secp256k1 + SHA-256) ---\n");
 
     // Vector 1: d=fee0...be1e, msg="test data"
     {
@@ -154,7 +154,7 @@ static void test_rfc6979_nonce_vectors() {
 // ============================================================================
 
 static void test_ecdsa_sign_vectors() {
-    printf("\n--- ECDSA Signature Vectors (secp256k1 + SHA-256) ---\n");
+    (void)printf("\n--- ECDSA Signature Vectors (secp256k1 + SHA-256) ---\n");
 
     // Vector 1: d=1, msg="Everything should be made as simple..."
     {
@@ -290,7 +290,7 @@ static void test_ecdsa_sign_vectors() {
 // ============================================================================
 
 static void test_ecdsa_verify_roundtrip() {
-    printf("\n--- ECDSA Verify Roundtrip ---\n");
+    (void)printf("\n--- ECDSA Verify Roundtrip ---\n");
 
     struct SignVerifyVec {
         const char* d_hex;
@@ -338,7 +338,7 @@ static void test_ecdsa_verify_roundtrip() {
 // ============================================================================
 
 static void test_ecdsa_determinism() {
-    printf("\n--- ECDSA Determinism ---\n");
+    (void)printf("\n--- ECDSA Determinism ---\n");
 
     auto priv = Scalar::from_hex(
         "e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35");
@@ -367,18 +367,18 @@ static void test_ecdsa_determinism() {
 // ============================================================================
 
 int test_rfc6979_vectors_run() {
-    printf("================================================================\n");
-    printf("  RFC 6979 Deterministic ECDSA Test Vectors (secp256k1)\n");
-    printf("================================================================\n");
+    (void)printf("================================================================\n");
+    (void)printf("  RFC 6979 Deterministic ECDSA Test Vectors (secp256k1)\n");
+    (void)printf("================================================================\n");
 
     test_rfc6979_nonce_vectors();
     test_ecdsa_sign_vectors();
     test_ecdsa_verify_roundtrip();
     test_ecdsa_determinism();
 
-    printf("\n================================================================\n");
-    printf("  Results: %d / %d passed\n", tests_passed, tests_run);
-    printf("================================================================\n");
+    (void)printf("\n================================================================\n");
+    (void)printf("  Results: %d / %d passed\n", tests_passed, tests_run);
+    (void)printf("================================================================\n");
 
     return (tests_passed == tests_run) ? 0 : 1;
 }

--- a/cpu/tests/test_v4_features.cpp
+++ b/cpu/tests/test_v4_features.cpp
@@ -351,6 +351,7 @@ static void test_base58check() {
     std::uint8_t payload[21] = {};  // version 0x00 + 20 zero bytes
     auto encoded = base58check_encode(payload, 21);
     CHECK(!encoded.empty(), "base58_encode_nonempty");
+    // cppcheck-suppress containerOutOfBounds
     CHECK(encoded[0] == '1', "base58_leading_ones");
 
     // Roundtrip

--- a/include/ufsecp/ufsecp_impl.cpp
+++ b/include/ufsecp/ufsecp_impl.cpp
@@ -59,6 +59,7 @@ static ufsecp_error_t ctx_set_err(ufsecp_ctx* ctx, ufsecp_error_t err, const cha
     if (msg) {
         /* Portable safe copy without MSVC deprecation warning */
         size_t i = 0;
+        /* cppcheck-suppress arrayIndexOutOfBoundsCond ; i bounded by sizeof(last_msg)-1 */
         for (; i < sizeof(ctx->last_msg) - 1 && msg[i]; ++i) {
             ctx->last_msg[i] = msg[i];
 }


### PR DESCRIPTION
## Summary
64 files changed, 705 insertions, 651 deletions across 14 alert categories.

## Categories Fixed
| Category | Count | Fix Type |
|---|---|---|
| objectIndex | 64 | cppcheck-suppress in sha512.hpp |
| cert-err33-c | 159 | (void) cast on I/O return values |
| cert-msc32-c | 44 | NOLINT on intentional test RNG seeds |
| bugprone-implicit-widening | 43 | static_cast on loop counters |
| misc-const-correctness | 37 | add const where safe |
| shiftTooManyBitsSigned | 16 | suppress sign-bit arithmetic shifts |
| StackAddressEscape | ~10 | NOLINTBEGIN for benchmark \\scape()\\ idiom |
| nullPointerRedundantCheck | 14 | suppress defensive null checks |
| arrayIndexOutOfBoundsCond | 6 | suppress bounded-loop FPs |
| containerOutOfBounds | 2 | suppress guarded access FP |
| uninitMemberVar | 2 | init RIPEMD160::buf_ |
| passedByValue | 1 | const ref for FieldElement |
| AssignmentAddressToInteger | 1 | fix pointer-to-integer |

## Verification
- Build: 48/48 targets OK
- Tests: 25/25 passed (100%)