### PR TITLE
fix: remove unused variable in audit_field.cpp (-Werror)

### DIFF
--- a/audit/audit_field.cpp
+++ b/audit/audit_field.cpp
@@ -274,9 +274,9 @@ static void test_canonical() {
         auto bytes = a.to_bytes();
 
         // Check bytes < P_BYTES (big-endian comparison)
-        bool less = false, greater = false;
+        bool greater = false;
         for (int j = 0; j < 32; ++j) {
-            if (bytes[j] < P_BYTES[j]) { less = true; break; }
+            if (bytes[j] < P_BYTES[j]) { break; }
             if (bytes[j] > P_BYTES[j]) { greater = true; break; }
         }
         CHECK(!greater, "serialized value < p or == 0");


### PR DESCRIPTION
Removes unused variable 'less' in audit_field.cpp:277 that triggers -Werror=unused-but-set-variable in the Security Audit CI job. Only 'greater' was ever checked -- simplified the early-exit branch.