### PR TITLE
fix: raise sanitizer test timeouts to prevent false CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,10 @@ jobs:
         run: cmake --build build/${{ matrix.sanitizer }} -j$(nproc)
 
       - name: Test (${{ matrix.label }})
-        run: ctest --test-dir build/${{ matrix.sanitizer }} --output-on-failure -j$(nproc) -E "^(ct_sidechannel|unified_audit)" --timeout 300
+        # Sanitizers add 3-15x overhead; raise per-test timeout from 300s to 900s.
+        # Exclude selftest (unified runner) -- standalone tests cover the same
+        # modules individually and finish faster under instrumentation.
+        run: ctest --test-dir build/${{ matrix.sanitizer }} --output-on-failure -j$(nproc) -E "^(ct_sidechannel|unified_audit|selftest)" --timeout 900
 
   # -- Windows (MSVC + Clang-cl) ----------------------------------------------
   windows:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -79,7 +79,9 @@ jobs:
         env:
           ASAN_OPTIONS: detect_leaks=1:halt_on_error=1
           UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
-        run: ctest --test-dir build --output-on-failure -j"$(nproc)" -E "^ct_sidechannel"
+        # Sanitizers add 3-15x overhead; raise per-test timeout and exclude
+        # selftest/unified_audit (standalone tests cover the same modules).
+        run: ctest --test-dir build --output-on-failure -j"$(nproc)" -E "^(ct_sidechannel|selftest|unified_audit)" --timeout 900
 
   # ── Valgrind memcheck ───────────────────────────────────────────────────
   valgrind:

--- a/audit/CMakeLists.txt
+++ b/audit/CMakeLists.txt
@@ -49,7 +49,7 @@ set_tests_properties(ct_sidechannel_smoke PROPERTIES TIMEOUT 120)
 add_executable(test_differential_standalone differential_test.cpp)
 audit_target_defaults(test_differential_standalone)
 add_test(NAME differential COMMAND test_differential_standalone)
-set_tests_properties(differential PROPERTIES TIMEOUT 120)
+set_tests_properties(differential PROPERTIES TIMEOUT 600)
 
 # -- FAST==CT equivalence test ---------------------------------------------
 add_executable(test_ct_equivalence_standalone ${CPU_TESTS_DIR}/test_ct_equivalence.cpp)
@@ -68,7 +68,7 @@ set_tests_properties(fault_injection PROPERTIES TIMEOUT 300)
 add_executable(test_debug_invariants test_debug_invariants.cpp)
 audit_target_defaults(test_debug_invariants)
 add_test(NAME debug_invariants COMMAND test_debug_invariants)
-set_tests_properties(debug_invariants PROPERTIES TIMEOUT 120)
+set_tests_properties(debug_invariants PROPERTIES TIMEOUT 600)
 
 # -- Fiat-Crypto comparison vectors ----------------------------------------
 add_executable(test_fiat_crypto_vectors test_fiat_crypto_vectors.cpp)
@@ -104,7 +104,7 @@ set_tests_properties(abi_gate PROPERTIES TIMEOUT 30)
 add_executable(test_audit_fuzz_standalone audit_fuzz.cpp)
 audit_target_defaults(test_audit_fuzz_standalone)
 add_test(NAME audit_fuzz COMMAND test_audit_fuzz_standalone)
-set_tests_properties(audit_fuzz PROPERTIES TIMEOUT 120)
+set_tests_properties(audit_fuzz PROPERTIES TIMEOUT 600)
 
 # -- Diagnostic: ct::scalar_mul step-by-step comparison --------------------
 add_executable(diag_scalar_mul ${CPU_TESTS_DIR}/diag_scalar_mul.cpp)
@@ -334,7 +334,7 @@ if(MSVC OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND WIN32))
     target_link_options(unified_audit_runner PRIVATE "LINKER:/STACK:8388608")
 endif()
 add_test(NAME unified_audit COMMAND unified_audit_runner)
-set_tests_properties(unified_audit PROPERTIES TIMEOUT 600)
+set_tests_properties(unified_audit PROPERTIES TIMEOUT 1200)
 
 # ===========================================================================
 # Full Audit Orchestrator (custom target)


### PR DESCRIPTION
## Fix: Sanitizer CI Timeout Failures

All sanitizer CI failures were **timeouts**, not actual bugs. Sanitizers
(ASan/UBSan/TSan) add 3-15x runtime overhead, making the 300s per-test
timeout insufficient for many tests.

### Failure Summary (before fix)
- **CI / Sanitizers (ASan+UBSan)**: 20/27 tests timed out
- **CI / Sanitizers (TSan)**: 4/27 tests timed out
- **Security Audit / ASan+UBSan**: 3 tests timed out

### Changes
1. **ci.yml**: raise ctest --timeout from 300s to 900s for sanitizer jobs
2. **ci.yml**: exclude selftest (unified runner) from sanitizer runs --
   standalone tests cover the same modules individually
3. **security-audit.yml**: add --timeout 900, exclude selftest + unified_audit
4. **audit/CMakeLists.txt**: raise per-test TIMEOUT for slow audit tests:
   - differential: 120s -> 600s
   - debug_invariants: 120s -> 600s
   - audit_fuzz: 120s -> 600s
   - unified_audit: 600s -> 1200s

### Evidence tests pass given enough time
Under ASan+UBSan, musig2_frost passed at 477s and frost_kat at 278s.
Under TSan, selftest printed "All tests PASSED" at exactly 300s (killed).
