### PR TITLE
ci: exclude audit/ from coverage measurement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,14 +479,14 @@ jobs:
             --format=lcov \
             --instr-profile=coverage.profdata \
             $OBJECTS \
-            --ignore-filename-regex='(tests/|bench/|examples/|/usr/)' \
+            --ignore-filename-regex='(tests/|bench/|examples/|audit/|/usr/)' \
             > coverage.lcov
 
           echo "=== Coverage summary ==="
           llvm-cov-17 report \
             --instr-profile=coverage.profdata \
             $OBJECTS \
-            --ignore-filename-regex='(tests/|bench/|examples/|/usr/)' \
+            --ignore-filename-regex='(tests/|bench/|examples/|audit/|/usr/)' \
             | tail -5
 
       - name: Upload to Codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -32,6 +32,7 @@ ignore:
   - "tests/**"
   - "bench/**"
   - "examples/**"
+  - "audit/**"
   - "wasm/**"
   - "android/**"
   - "bindings/**"


### PR DESCRIPTION
## Problem
`codecov/patch` reports 0.00% on PRs that only modify `audit/` files (test, benchmark, audit-runner code). The target is 80%, blocking merges.

## Root Cause
`audit/` was missing from both:
- `codecov.yml` ignore list
- `ci.yml` llvm-cov `--ignore-filename-regex`

So Codecov treats audit code as production source requiring patch coverage.

## Fix
- Add `audit/**` to `codecov.yml` ignore section (alongside existing `tests/**`, `bench/**`, etc.)
- Add `audit/` to the `--ignore-filename-regex` in the CI coverage export step

## Verification
No code changes -- only CI config. Future PRs touching only audit/test files will no longer trigger the patch coverage gate.