### PR TITLE
ci: make codecov/patch informational (non-blocking)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -21,6 +21,7 @@ coverage:
       default:
         target: 80%         # new code should have ≥80% coverage
         threshold: 5%
+        informational: true # report only -- never block PRs
 
   # Only measure coverage on production source code
   # (exclude tests, benchmarks, examples, third-party, build artifacts)


### PR DESCRIPTION
## Problem
`codecov/patch` reports **0.00%** (target 80%) on diffs that touch only non-source files (YAML, config) or ignored directories -- there are zero coverable lines in the diff, so patch coverage is undefined/0%.

## Fix
Add `informational: true` to the `patch.default` status in `codecov.yml`.

This makes `codecov/patch` always report a **neutral** commit status instead of failure. The coverage result is still visible in the PR comment, but it will never block a merge.

The **project-level** coverage gate (`target: auto`, `threshold: 1%`) remains enforced and protects against actual coverage regressions.