### PR TITLE
fix: android CI -- skip bench_hornet when libsecp source absent

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -108,30 +108,36 @@ target_link_options(bench_comprehensive PRIVATE -static-libstdc++)
 
 # ============================================================================
 # Bench Hornet (Bitcoin Consensus full benchmark with libsecp256k1 apple-to-apple)
+# Requires libsecp256k1 source tree -- skip gracefully when absent (e.g. CI)
 # ============================================================================
 set(LIBSECP_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../_research_repos/secp256k1/src")
 
-add_executable(bench_hornet
-    test/bench_hornet_android.cpp
-    test/libsecp_bench.c
-    ${LIBSECP_SRC_DIR}/precomputed_ecmult.c
-    ${LIBSECP_SRC_DIR}/precomputed_ecmult_gen.c
-)
-target_link_libraries(bench_hornet PRIVATE fastsecp256k1)
-target_include_directories(bench_hornet PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/../cpu/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../_research_repos/secp256k1/include
-    ${LIBSECP_SRC_DIR}
-)
-target_compile_features(bench_hornet PRIVATE cxx_std_20)
-target_compile_options(bench_hornet PRIVATE -O3)
-target_link_options(bench_hornet PRIVATE -static-libstdc++)
-target_link_options(bench_comprehensive PRIVATE -static-libstdc++)
+if(EXISTS "${LIBSECP_SRC_DIR}/secp256k1.c")
+    add_executable(bench_hornet
+        test/bench_hornet_android.cpp
+        test/libsecp_bench.c
+        ${LIBSECP_SRC_DIR}/precomputed_ecmult.c
+        ${LIBSECP_SRC_DIR}/precomputed_ecmult_gen.c
+    )
+    target_link_libraries(bench_hornet PRIVATE fastsecp256k1)
+    target_include_directories(bench_hornet PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../cpu/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../_research_repos/secp256k1/include
+        ${LIBSECP_SRC_DIR}
+    )
+    target_compile_features(bench_hornet PRIVATE cxx_std_20)
+    target_compile_options(bench_hornet PRIVATE -O3)
+    target_link_options(bench_hornet PRIVATE -static-libstdc++)
+    set(_bench_hornet_status "bench_hornet       - Bitcoin Consensus bench + libsecp256k1 apple-to-apple")
+else()
+    message(STATUS "bench_hornet: skipped (libsecp256k1 source not found at ${LIBSECP_SRC_DIR})")
+    set(_bench_hornet_status "bench_hornet       - SKIPPED (libsecp256k1 source not found)")
+endif()
 
 message(STATUS "Targets available:")
 message(STATUS "  fastsecp256k1      - Static library (link into your native code)")
 message(STATUS "  secp256k1_jni      - Shared JNI library (for Java/Kotlin apps)")
 message(STATUS "  android_test       - On-device test binary (adb push + adb shell)")
 message(STATUS "  bench_comprehensive - Cross-platform benchmark (adb push + adb shell)")
-message(STATUS "  bench_hornet       - Bitcoin Consensus bench + libsecp256k1 apple-to-apple")
+message(STATUS "  ${_bench_hornet_status}")


### PR DESCRIPTION
The android/CMakeLists.txt unconditionally adds bench_hornet which requires _research_repos/secp256k1/ source tree. In CI this directory does not exist, causing CMake configure failure for all 3 Android ABI jobs (arm64-v8a, armeabi-v7a, x86_64).\n\nFix: wrap bench_hornet target in EXISTS check, same pattern already applied in cpu/CMakeLists.txt.