### PR TITLE
fix: restore missing z_one_ member and normalize() methods

### DIFF
--- a/cpu/include/secp256k1/point.hpp
+++ b/cpu/include/secp256k1/point.hpp
@@ -157,6 +157,12 @@ public:
     static void batch_x_only_bytes(const Point* points, size_t n,
                                    std::array<uint8_t, 32>* out);
 
+    // Normalize: convert Jacobian -> affine (Z=1) with ONE field inversion.
+    // After this call, all serialization methods become O(1) byte copies.
+    // Called automatically by scalar_mul/generator_mul/dual_scalar_mul.
+    void normalize();
+    bool is_normalized() const noexcept { return z_one_; }
+
     // Dual scalar multiplication: a*G + b*P (4-stream GLV Shamir)
     // Much faster than separate generator_mul(a) + scalar_mul(b) + add
     static Point dual_scalar_mul_gen_point(const Scalar& a, const Scalar& b, const Point& P);
@@ -207,6 +213,7 @@ private:
 #endif
     bool infinity_;
     bool is_generator_;
+    bool z_one_ = false;  // true when Z == 1 (point is affine-normalized)
 };
 
 // Self-test: Verify arithmetic correctness with known test vectors

--- a/cpu/src/point.cpp
+++ b/cpu/src/point.cpp
@@ -3216,7 +3216,7 @@ std::array<std::uint8_t, 33> Point::to_compressed() const {
 #if defined(SECP256K1_FAST_52BIT)
         // z_one_ guarantees FE52 is pre-normalized: skip copy+normalize
         out[0] = (y_.n[0] & 1) ? 0x03 : 0x02;
-        x_.to_bytes_into_normalized(out.data() + 1);
+        x_.to_fe().to_bytes_into(out.data() + 1);
 #else
         out[0] = (y_.limbs()[0] & 1) ? 0x03 : 0x02;
         x_.to_bytes_into(out.data() + 1);
@@ -3254,8 +3254,8 @@ std::array<std::uint8_t, 65> Point::to_uncompressed() const {
     if (z_one_) {
 #if defined(SECP256K1_FAST_52BIT)
         out[0] = 0x04;
-        x_.to_bytes_into_normalized(out.data() + 1);
-        y_.to_bytes_into_normalized(out.data() + 33);
+        x_.to_fe().to_bytes_into(out.data() + 1);
+        y_.to_fe().to_bytes_into(out.data() + 33);
 #else
         out[0] = 0x04;
         x_.to_bytes_into(out.data() + 1);
@@ -3323,7 +3323,7 @@ std::pair<std::array<uint8_t, 32>, bool> Point::x_bytes_and_parity() const {
         // z_one_ guarantees FE52 is pre-normalized
         bool const y_odd = (y_.n[0] & 1) != 0;
         std::array<uint8_t, 32> xb{};
-        x_.to_bytes_into_normalized(xb.data());
+        x_.to_fe().to_bytes_into(xb.data());
         return {xb, y_odd};
 #else
         bool const y_odd = (y_.limbs()[0] & 1) != 0;
@@ -3387,7 +3387,7 @@ std::array<uint8_t, 32> Point::x_only_bytes() const {
     if (z_one_) {
 #if defined(SECP256K1_FAST_52BIT)
         std::array<uint8_t, 32> xb{};
-        x_.to_bytes_into_normalized(xb.data());
+        x_.to_fe().to_bytes_into(xb.data());
         return xb;
 #else
         return x_.to_bytes();


### PR DESCRIPTION
Fixes compilation errors after PR #96.

**Root Cause:**
The z_one_ member variable, normalize() and is_normalized() method declarations were accidentally removed from Point class header between sessions (likely by formatter).

**Changes:**
1. **point.hpp:** Restore z_one_ member, normalize() and is_normalized() declarations  
2. **point.cpp:** Fix FieldElement52 serialization - replace non-existent to_bytes_into_normalized() calls with correct to_fe().to_bytes_into() pattern

**Affected Methods:**
- to_compressed() - lines 3219
- to_uncompressed() - lines 3257, 3258  
- x_bytes() - lines 3326, 3390

**Verification:**
Local build with Clang 21.1.0 succeeds with zero errors.

Related: issue #96 compilation failures