### PR TITLE
fix(sonarcloud): add FieldElement52::to_bytes_into() to eliminate code duplication

### DIFF
--- a/cpu/include/secp256k1/field_52.hpp
+++ b/cpu/include/secp256k1/field_52.hpp
@@ -67,6 +67,10 @@ struct alignas(8) FieldElement52 {
     static FieldElement52 from_fe(const FieldElement& fe) noexcept;
     FieldElement to_fe() const noexcept;  // Normalizes first!
 
+    // Convenience: serialize FE52 -> bytes (BE) in one call.
+    // Replaces common pattern: to_fe().to_bytes_into(out)
+    void to_bytes_into(std::uint8_t* out) const noexcept;
+
     // Direct 4x64 limbs -> 5x52 conversion (zero-copy, no FieldElement construction).
     // Input: 4 little-endian uint64_t limbs representing a value < p.
     // Use for Scalar->FE52 where we know value < n < p.

--- a/cpu/include/secp256k1/field_52_impl.hpp
+++ b/cpu/include/secp256k1/field_52_impl.hpp
@@ -1073,6 +1073,12 @@ FieldElement FieldElement52::to_fe() const noexcept {
     return FieldElement::from_limbs_raw(L);  // already canonical -- skip redundant normalize
 }
 
+// Convenience serialization: FE52 -> bytes in one call
+SECP256K1_FE52_FORCE_INLINE
+void FieldElement52::to_bytes_into(std::uint8_t* out) const noexcept {
+    to_fe().to_bytes_into(out);
+}
+
 // -- Direct 4x64 limbs -> 5x52 (no FieldElement construction) -------------
 // Same bit-slicing as from_fe but takes raw uint64_t[4] pointer.
 // Avoids FieldElement copy + normalization when caller knows value < p.

--- a/cpu/src/point.cpp
+++ b/cpu/src/point.cpp
@@ -3216,7 +3216,7 @@ std::array<std::uint8_t, 33> Point::to_compressed() const {
 #if defined(SECP256K1_FAST_52BIT)
         // z_one_ guarantees FE52 is pre-normalized: skip copy+normalize
         out[0] = (y_.n[0] & 1) ? 0x03 : 0x02;
-        x_.to_fe().to_bytes_into(out.data() + 1);
+        x_.to_bytes_into(out.data() + 1);
 #else
         out[0] = (y_.limbs()[0] & 1) ? 0x03 : 0x02;
         x_.to_bytes_into(out.data() + 1);
@@ -3254,8 +3254,8 @@ std::array<std::uint8_t, 65> Point::to_uncompressed() const {
     if (z_one_) {
 #if defined(SECP256K1_FAST_52BIT)
         out[0] = 0x04;
-        x_.to_fe().to_bytes_into(out.data() + 1);
-        y_.to_fe().to_bytes_into(out.data() + 33);
+        x_.to_bytes_into(out.data() + 1);
+        y_.to_bytes_into(out.data() + 33);
 #else
         out[0] = 0x04;
         x_.to_bytes_into(out.data() + 1);
@@ -3323,7 +3323,7 @@ std::pair<std::array<uint8_t, 32>, bool> Point::x_bytes_and_parity() const {
         // z_one_ guarantees FE52 is pre-normalized
         bool const y_odd = (y_.n[0] & 1) != 0;
         std::array<uint8_t, 32> xb{};
-        x_.to_fe().to_bytes_into(xb.data());
+        x_.to_bytes_into(xb.data());
         return {xb, y_odd};
 #else
         bool const y_odd = (y_.limbs()[0] & 1) != 0;
@@ -3387,7 +3387,7 @@ std::array<uint8_t, 32> Point::x_only_bytes() const {
     if (z_one_) {
 #if defined(SECP256K1_FAST_52BIT)
         std::array<uint8_t, 32> xb{};
-        x_.to_fe().to_bytes_into(xb.data());
+        x_.to_bytes_into(xb.data());
         return xb;
 #else
         return x_.to_bytes();


### PR DESCRIPTION
## Problem

SonarCloud Quality Gate failed on PR #97 with 4.1% code duplication (threshold: 3%).

The duplication came from 5 instances of the FE52 serialization pattern:
\\\cpp
x_.to_fe().to_bytes_into(out);
\\\

## Solution

Add \FieldElement52::to_bytes_into()\ convenience method that wraps this common pattern.

### Changes
- **field_52.hpp**: Add \	o_bytes_into(std::uint8_t*)\ declaration
- **field_52_impl.hpp**: Add inline implementation (calls \	o_fe().to_bytes_into(out)\)
- **point.cpp**: Replace 5 duplicated instances with the new method

### Impact
- **Code duplication**: 4.1% → <3% (passes quality gate)
- **API consistency**: Matches existing helpers like \inverse_safegcd()\, \rom_bytes()\
- **Performance**: Zero overhead (fully inlined)
- **Readability**: Cleaner callsites (\x_.to_bytes_into(out)\ vs \x_.to_fe().to_bytes_into(out)\)

## Testing
- ✅ Local build (Clang 21.1.0 Windows): SUCCESS
- ⏳ Waiting for CI (26 workflows)
- ⏳ SonarCloud analysis expected to pass

Addresses quality gate failure from #97.