### PR TITLE
fix(ci): disable LTO in ClusterFuzzLite fuzz build

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -29,7 +29,8 @@ cmake -S . -B build-fuzz -G Ninja \
     -DSECP256K1_BUILD_BENCH=OFF \
     -DSECP256K1_BUILD_EXAMPLES=OFF \
     -DSECP256K1_BUILD_METAL=OFF \
-    -DSECP256K1_USE_ASM=OFF
+    -DSECP256K1_USE_ASM=OFF \
+    -DSECP256K1_USE_LTO=OFF
 
 cmake --build build-fuzz -j"$(nproc)" --target fastsecp256k1
 


### PR DESCRIPTION
ClusterFuzzLite CFL Batch (address) fails with:

```
/usr/bin/ld: libfastsecp256k1.a: error adding symbols: file format not recognized
```

**Root cause**: `SECP256K1_USE_LTO` defaults to `ON`, producing LLVM bitcode `.o` files. ClusterFuzzLite's Step 2 links with `/usr/bin/ld` (not `lld`), which cannot parse bitcode.

**Fix**: Add `-DSECP256K1_USE_LTO=OFF` to `.clusterfuzzlite/build.sh` so the static archive contains regular ELF objects.

Addresses CI failure in #117