### PR TITLE
fix: resolve 5 open clang-tidy code scanning alerts

### DIFF
--- a/cpu/src/point.cpp
+++ b/cpu/src/point.cpp
@@ -3781,9 +3781,9 @@ void Point::batch_normalize(const Point* points, size_t n,
             partials[i] = running; // skip infinity, don't multiply
         } else {
 #if defined(SECP256K1_FAST_52BIT)
-            FieldElement z_fe = points[i].z_.to_fe();
+            const FieldElement z_fe = points[i].z_.to_fe();
 #else
-            auto z_fe = points[i].z_;
+            const auto z_fe = points[i].z_;
 #endif
             partials[i] = running;
             running *= z_fe;

--- a/cpu/src/scalar.cpp
+++ b/cpu/src/scalar.cpp
@@ -338,9 +338,9 @@ Scalar Scalar::operator*(const Scalar& rhs) const {
 
     // {c0,c1,c2} += x * y
     auto muladd = [&](std::uint64_t x, std::uint64_t y) {
-        unsigned __int128 p = static_cast<unsigned __int128>(x) * y;
-        const std::uint64_t tl = static_cast<std::uint64_t>(p);
-        std::uint64_t th = static_cast<std::uint64_t>(p >> 64);
+        const unsigned __int128 p = static_cast<unsigned __int128>(x) * y;
+        const auto tl = static_cast<std::uint64_t>(p);
+        auto th = static_cast<std::uint64_t>(p >> 64);
         c0 += tl;
         th += (c0 < tl);
         c1 += th;

--- a/cpu/src/schnorr.cpp
+++ b/cpu/src/schnorr.cpp
@@ -106,10 +106,10 @@ static inline void parse_be32_to_le64(const uint8_t* in32, std::uint64_t* out4) 
 
 static inline bool limbs_lt_p(const std::uint64_t* x4) {
     constexpr std::uint64_t P0 = 0xFFFFFFFEFFFFFC2FULL;
-    return !(x4[3] == 0xFFFFFFFFFFFFFFFFULL &&
-             x4[2] == 0xFFFFFFFFFFFFFFFFULL &&
-             x4[1] == 0xFFFFFFFFFFFFFFFFULL &&
-             x4[0] >= P0);
+    return x4[3] != 0xFFFFFFFFFFFFFFFFULL ||
+           x4[2] != 0xFFFFFFFFFFFFFFFFULL ||
+           x4[1] != 0xFFFFFFFFFFFFFFFFULL ||
+           x4[0] < P0;
 }
 
 static inline bool parse_and_check_lt_p(const uint8_t* in32, std::uint64_t* out4) {
@@ -155,7 +155,7 @@ static inline bool lift_x_cached(const uint8_t* pubkey_x32,
     // Direct-mapped table keeps lookup O(1) with minimal branch/memcmp overhead.
     static constexpr std::size_t kCacheSlots = 256;
     thread_local std::array<XOnlyLiftCacheEntry, kCacheSlots> cache{};
-    std::size_t const idx = static_cast<std::size_t>(
+    auto const idx = static_cast<std::size_t>(
         pubkey_x32[0] ^ pubkey_x32[7] ^ pubkey_x32[15] ^ pubkey_x32[23] ^ pubkey_x32[31]);
 
     auto& slot = cache[idx];


### PR DESCRIPTION
Resolves all 5 open clang-tidy alerts from code scanning:

| Alert | File | Rule | Fix |
|-------|------|------|-----|
| #6982 | schnorr.cpp:109 | readability-simplify-boolean-expr | DeMorgan simplification |
| #6983 | point.cpp:3784 | misc-const-correctness | Add const to z_fe |
| #6984 | scalar.cpp:341 | misc-const-correctness | Add const to __int128 p |
| #6985 | scalar.cpp:342 | modernize-use-auto | Use auto with static_cast |
| #6986 | schnorr.cpp:158 | modernize-use-auto | Use auto with static_cast |

All 31 tests pass. No behavioral changes.