### PR TITLE
fix: resolve 6 clang-tidy code scanning alerts

### DIFF
--- a/cpu/src/field.cpp
+++ b/cpu/src/field.cpp
@@ -2308,7 +2308,7 @@ FieldElement FieldElement::from_uint64(std::uint64_t value) {
 }
 
 inline std::uint64_t load_be64(const std::uint8_t* p) noexcept {
-    std::uint64_t v;
+    std::uint64_t v = 0;
     std::memcpy(&v, p, 8);
 #if defined(__GNUC__) || defined(__clang__)
     return __builtin_bswap64(v);

--- a/include/ufsecp/ufsecp_impl.cpp
+++ b/include/ufsecp/ufsecp_impl.cpp
@@ -346,7 +346,7 @@ ufsecp_error_t ufsecp_pubkey_create(ufsecp_ctx* ctx,
     if (!ctx || !privkey || !pubkey33_out) return UFSECP_ERR_NULL_ARG;
     ctx_clear_err(ctx);
     Point pk;
-    ufsecp_error_t err = pubkey_create_core(ctx, privkey, pk);
+    const ufsecp_error_t err = pubkey_create_core(ctx, privkey, pk);
     if (err != UFSECP_OK) return err;
     point_to_compressed(pk, pubkey33_out);
     return UFSECP_OK;
@@ -358,7 +358,7 @@ ufsecp_error_t ufsecp_pubkey_create_uncompressed(ufsecp_ctx* ctx,
     if (!ctx || !privkey || !pubkey65_out) return UFSECP_ERR_NULL_ARG;
     ctx_clear_err(ctx);
     Point pk;
-    ufsecp_error_t err = pubkey_create_core(ctx, privkey, pk);
+    const ufsecp_error_t err = pubkey_create_core(ctx, privkey, pk);
     if (err != UFSECP_OK) return err;
     auto uncomp = pk.to_uncompressed();
     std::memcpy(pubkey65_out, uncomp.data(), 65);
@@ -812,7 +812,7 @@ ufsecp_error_t ufsecp_ecdh(ufsecp_ctx* ctx,
     if (!ctx || !privkey || !pubkey33 || !secret32_out) return UFSECP_ERR_NULL_ARG;
     ctx_clear_err(ctx);
     Scalar sk; Point pk;
-    ufsecp_error_t err = ecdh_parse_args(ctx, privkey, pubkey33, sk, pk);
+    const ufsecp_error_t err = ecdh_parse_args(ctx, privkey, pubkey33, sk, pk);
     if (err != UFSECP_OK) return err;
     auto secret = secp256k1::ecdh_compute(sk, pk);
     std::memcpy(secret32_out, secret.data(), 32);
@@ -826,7 +826,7 @@ ufsecp_error_t ufsecp_ecdh_xonly(ufsecp_ctx* ctx,
     if (!ctx || !privkey || !pubkey33 || !secret32_out) return UFSECP_ERR_NULL_ARG;
     ctx_clear_err(ctx);
     Scalar sk; Point pk;
-    ufsecp_error_t err = ecdh_parse_args(ctx, privkey, pubkey33, sk, pk);
+    const ufsecp_error_t err = ecdh_parse_args(ctx, privkey, pubkey33, sk, pk);
     if (err != UFSECP_OK) return err;
     auto secret = secp256k1::ecdh_compute_xonly(sk, pk);
     std::memcpy(secret32_out, secret.data(), 32);
@@ -840,7 +840,7 @@ ufsecp_error_t ufsecp_ecdh_raw(ufsecp_ctx* ctx,
     if (!ctx || !privkey || !pubkey33 || !secret32_out) return UFSECP_ERR_NULL_ARG;
     ctx_clear_err(ctx);
     Scalar sk; Point pk;
-    ufsecp_error_t err = ecdh_parse_args(ctx, privkey, pubkey33, sk, pk);
+    const ufsecp_error_t err = ecdh_parse_args(ctx, privkey, pubkey33, sk, pk);
     if (err != UFSECP_OK) return err;
     auto secret = secp256k1::ecdh_compute_raw(sk, pk);
     std::memcpy(secret32_out, secret.data(), 32);


### PR DESCRIPTION
Resolves 6 open code scanning alerts introduced by the refactoring in PR #110:

- **#6987** field.cpp:2311 `cppcoreguidelines-init-variables`: initialize `v` in `load_be64`
- **#6988-#6989** ufsecp_impl.cpp `misc-const-correctness`: add `const` to `err` in `pubkey_create` / `pubkey_create_uncompressed`
- **#6990-#6992** ufsecp_impl.cpp `misc-const-correctness`: add `const` to `err` in 3 ECDH functions

31/31 tests pass.