### PR TITLE
fix(ci): handle immutable GitHub releases in packaging workflow

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -166,26 +166,55 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${GITHUB_REF_NAME}"
-          # Wait for the release to be created by the Release workflow.
+
+          # Collect package files
+          mapfile -t PKG_FILES < <(find packages -type f \( -name '*.deb' -o -name '*.rpm' \))
+          if [ ${#PKG_FILES[@]} -eq 0 ]; then
+            echo "::error::No .deb or .rpm packages found"
+            exit 1
+          fi
+          echo "Found ${#PKG_FILES[@]} package(s) to upload"
+
+          # Wait for the release to be created (by manual gh release create or another workflow).
           # Retry up to 30 times (15 min total) with 30s intervals.
+          RELEASE_EXISTED=false
           for i in $(seq 1 30); do
             if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
-              echo "Release $TAG exists, uploading packages..."
+              echo "Release $TAG found."
+              RELEASE_EXISTED=true
               break
             fi
             if [ "$i" -eq 30 ]; then
-              echo "WARNING: Release $TAG not found after 30 retries, creating minimal release..."
+              echo "Release $TAG not found after 30 retries, creating minimal release..."
               gh release create "$TAG" --repo "$GITHUB_REPOSITORY" \
                 --title "UltrafastSecp256k1 $TAG" \
-                --notes "Release created by packaging workflow (release workflow pending)."
-              break
+                --notes "Release created by packaging workflow." \
+                "${PKG_FILES[@]}"
+              echo "Release created with packages attached."
+              exit 0
             fi
-            echo "Waiting for release $TAG to be created (attempt $i/30)..."
+            echo "Waiting for release $TAG (attempt $i/30)..."
             sleep 30
           done
-          # Upload .deb and .rpm files (--clobber overwrites if already present)
-          find packages -type f \( -name '*.deb' -o -name '*.rpm' \) -print0 | \
-            xargs -0 -r gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber
+
+          # Try direct upload (works for mutable releases)
+          if gh release upload "$TAG" "${PKG_FILES[@]}" \
+               --repo "$GITHUB_REPOSITORY" --clobber 2>/dev/null; then
+            echo "Packages uploaded successfully."
+          else
+            echo "Direct upload failed (release may be immutable), recreating..."
+            # Preserve existing release metadata
+            TITLE=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json name -q .name)
+            BODY=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body -q .body)
+            # Delete the immutable release (tag is preserved)
+            gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --yes
+            # Recreate with saved metadata + packages
+            gh release create "$TAG" "${PKG_FILES[@]}" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TITLE" \
+              --notes "$BODY"
+            echo "Release recreated with packages attached."
+          fi
 
       - name: Build APT repository
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Addresses packaging workflow failure on v3.20.0 release.

**Problem:** `gh release upload --clobber` fails with HTTP 422 when the GitHub release is immutable. All .deb and .rpm packages fail to attach.

**Fix:** If direct upload fails, the workflow now:
1. Saves existing release metadata (title + body)
2. Deletes the immutable release (tag is preserved)
3. Recreates the release with saved metadata + packages in one call

Also: when the release doesn't exist and the workflow creates it as a fallback, packages are now attached in the same `gh release create` call instead of a separate upload step.