### PR TITLE
fix(sonar): exclude cuda/** from coverage (no GPU on CI)

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -24,13 +24,15 @@ sonar.exclusions=\
   GenTools/**
 
 # Coverage / test exclusions
+# CUDA (.cu/.cuh) requires a GPU -- uninstrumentable on CPU-only CI runners.
 # Platform-specific runtime dispatch files (field_asm*, field_simd*) contain
 # #ifdef branches for MSVC/GCC/Clang and x86/ARM64 that can never all execute
 # on a single CI platform. Assembly (.S) files are not instrumentable.
+# field_asm52_arm64.cpp is ARM64-only intrinsics, dead code on x86 CI.
 sonar.coverage.exclusions=\
   cpu/tests/**,\
   cpu/bench/**,\
-  cuda/bench/**,\
+  cuda/**,\
   audit/**,\
   include/ufsecp/**,\
   **/benchmark*.hpp,\


### PR DESCRIPTION
## Problem

SonarCloud Quality Gate still failing: **73.7% Coverage on New Code** (required >= 80%).

## Root Cause

`sonar.sources` includes `cuda/src,cuda/include` but only `cuda/bench/**` was excluded from coverage. All other CUDA files (`.cu`, `.cuh`) cannot be compiled or instrumented on the CPU-only SonarCloud CI runner -- no nvcc, no GPU. Any lines changed in CUDA files count as uncovered 'new code', dragging the metric below 80%.

## Fix

Changed `cuda/bench/**` to `cuda/**` in `sonar.coverage.exclusions` to exclude all CUDA sources from coverage measurement.