### PR TITLE
test: add coverage for CT PrivateKey overloads and FE52 conditional_negate

### DIFF
--- a/cpu/tests/test_ct.cpp
+++ b/cpu/tests/test_ct.cpp
@@ -23,6 +23,7 @@
 #include "secp256k1/ct/sign.hpp"
 #include "secp256k1/ecdsa.hpp"
 #include "secp256k1/schnorr.hpp"
+#include "secp256k1/private_key.hpp"
 #include <iostream>
 #include <iomanip>
 #include <cstring>
@@ -537,6 +538,87 @@ static void test_ct_schnorr_pubkey() {
     CHECK(ct_px == gx, "ct::schnorr_pubkey(1) == G.x");
 }
 
+// --- CT PrivateKey Overload Tests --------------------------------------------
+// Exercise the inline PrivateKey overloads in ct/sign.hpp so they are covered.
+
+static void test_ct_privatekey_ecdsa() {
+    // Create a PrivateKey via from_bytes (key = 1)
+    std::array<uint8_t, 32> raw{};
+    raw[31] = 0x01;
+    secp256k1::PrivateKey pk;
+    CHECK(secp256k1::PrivateKey::from_bytes(raw, pk),
+          "PrivateKey::from_bytes(1) succeeds");
+
+    std::array<uint8_t, 32> msg_hash{};
+    msg_hash[0] = 0x42; msg_hash[1] = 0xAB; msg_hash[31] = 0x01;
+
+    // ecdsa_sign(PrivateKey) vs ecdsa_sign(Scalar)
+    auto sig_pk = secp256k1::ct::ecdsa_sign(msg_hash, pk);
+    auto sig_sc = secp256k1::ct::ecdsa_sign(msg_hash, pk.scalar());
+    CHECK(sig_pk.r.to_bytes() == sig_sc.r.to_bytes(),
+          "ct::ecdsa_sign(PrivateKey).r == ct::ecdsa_sign(Scalar).r");
+    CHECK(sig_pk.s.to_bytes() == sig_sc.s.to_bytes(),
+          "ct::ecdsa_sign(PrivateKey).s == ct::ecdsa_sign(Scalar).s");
+
+    // ecdsa_sign_verified(PrivateKey) vs ecdsa_sign_verified(Scalar)
+    auto sig_v_pk = secp256k1::ct::ecdsa_sign_verified(msg_hash, pk);
+    auto sig_v_sc = secp256k1::ct::ecdsa_sign_verified(msg_hash, pk.scalar());
+    CHECK(sig_v_pk.r.to_bytes() == sig_v_sc.r.to_bytes(),
+          "ct::ecdsa_sign_verified(PrivateKey).r matches Scalar");
+    CHECK(sig_v_pk.s.to_bytes() == sig_v_sc.s.to_bytes(),
+          "ct::ecdsa_sign_verified(PrivateKey).s matches Scalar");
+}
+
+static void test_ct_privatekey_ecdsa_hedged() {
+    std::array<uint8_t, 32> raw{};
+    raw[31] = 0x03;
+    secp256k1::PrivateKey pk;
+    CHECK(secp256k1::PrivateKey::from_bytes(raw, pk),
+          "PrivateKey::from_bytes(3) succeeds");
+
+    std::array<uint8_t, 32> msg_hash{};
+    msg_hash[0] = 0xDE; msg_hash[1] = 0xAD;
+
+    std::array<uint8_t, 32> aux{};
+    aux[0] = 0x01;
+
+    // ecdsa_sign_hedged(PrivateKey) vs ecdsa_sign_hedged(Scalar)
+    auto sig_pk = secp256k1::ct::ecdsa_sign_hedged(msg_hash, pk, aux);
+    auto sig_sc = secp256k1::ct::ecdsa_sign_hedged(msg_hash, pk.scalar(), aux);
+    CHECK(sig_pk.r.to_bytes() == sig_sc.r.to_bytes(),
+          "ct::ecdsa_sign_hedged(PrivateKey).r matches Scalar");
+    CHECK(sig_pk.s.to_bytes() == sig_sc.s.to_bytes(),
+          "ct::ecdsa_sign_hedged(PrivateKey).s matches Scalar");
+
+    // ecdsa_sign_hedged_verified(PrivateKey) vs ecdsa_sign_hedged_verified(Scalar)
+    auto sig_hv_pk = secp256k1::ct::ecdsa_sign_hedged_verified(msg_hash, pk, aux);
+    auto sig_hv_sc = secp256k1::ct::ecdsa_sign_hedged_verified(msg_hash, pk.scalar(), aux);
+    CHECK(sig_hv_pk.r.to_bytes() == sig_hv_sc.r.to_bytes(),
+          "ct::ecdsa_sign_hedged_verified(PrivateKey).r matches Scalar");
+    CHECK(sig_hv_pk.s.to_bytes() == sig_hv_sc.s.to_bytes(),
+          "ct::ecdsa_sign_hedged_verified(PrivateKey).s matches Scalar");
+}
+
+static void test_ct_privatekey_schnorr() {
+    std::array<uint8_t, 32> raw{};
+    raw[31] = 0x02;
+    secp256k1::PrivateKey pk;
+    CHECK(secp256k1::PrivateKey::from_bytes(raw, pk),
+          "PrivateKey::from_bytes(2) succeeds");
+
+    // schnorr_pubkey(PrivateKey) vs schnorr_pubkey(Scalar)
+    auto px_pk = secp256k1::ct::schnorr_pubkey(pk);
+    auto px_sc = secp256k1::ct::schnorr_pubkey(pk.scalar());
+    CHECK(px_pk == px_sc,
+          "ct::schnorr_pubkey(PrivateKey) matches Scalar");
+
+    // schnorr_keypair_create(PrivateKey) vs schnorr_keypair_create(Scalar)
+    auto kp_pk = secp256k1::ct::schnorr_keypair_create(pk);
+    auto kp_sc = secp256k1::ct::schnorr_keypair_create(pk.scalar());
+    CHECK(kp_pk.px == kp_sc.px,
+          "ct::schnorr_keypair_create(PrivateKey).px matches Scalar");
+}
+
 // --- Main --------------------------------------------------------------------
 
 int test_ct_run() {
@@ -609,6 +691,12 @@ int test_ct_run() {
     test_ct_ecdsa_sign();
     test_ct_schnorr_sign();
     test_ct_schnorr_pubkey();
+
+    // CT PrivateKey overloads
+    std::cout << "--- CT PrivateKey Overloads ---\n";
+    test_ct_privatekey_ecdsa();
+    test_ct_privatekey_ecdsa_hedged();
+    test_ct_privatekey_schnorr();
 
     // Summary
     std::cout << "\n=== Results: " << g_pass << " passed, " << g_fail << " failed ===\n";

--- a/cpu/tests/test_field_52.cpp
+++ b/cpu/tests/test_field_52.cpp
@@ -344,6 +344,39 @@ void test_commutativity_associativity() {
     CHECK(dist_left == dist_right, "a*(b+c) == a*b + a*c");
 }
 
+// -- conditional_negate_assign ------------------------------------------------
+// sign_mask=0 keeps value unchanged, sign_mask=-1 negates.
+void test_conditional_negate_assign() {
+    (void)std::printf("  conditional_negate_assign...\n");
+
+    // Zero mask: value should remain unchanged
+    FieldElement const a64 = FieldElement::from_hex(
+        "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798");
+    FieldElement52 a = FieldElement52::from_fe(a64);
+    FieldElement52 const orig = a;
+    a.conditional_negate_assign(0);
+    CHECK(a == orig, "cneg(0) keeps value unchanged");
+
+    // -1 mask: value should be negated (2P - a)
+    FieldElement52 b = FieldElement52::from_fe(a64);
+    b.conditional_negate_assign(-1);
+    // Negating twice should return to original
+    b.conditional_negate_assign(-1);
+    b.normalize();
+    FieldElement52 orig_norm = orig;
+    orig_norm.normalize();
+    CHECK(b == orig_norm, "cneg(-1) twice returns to original");
+
+    // Check that single negate gives -(a) mod p: a + (-a) == 0
+    FieldElement52 c = FieldElement52::from_fe(a64);
+    c.normalize();
+    FieldElement52 neg_c = c;
+    neg_c.conditional_negate_assign(-1);
+    FieldElement52 sum = c + neg_c;
+    sum.normalize();
+    CHECK(sum == FieldElement52::zero(), "a + cneg(-1,a) == 0");
+}
+
 } // anonymous namespace
 
 #ifdef STANDALONE_TEST
@@ -365,6 +398,7 @@ int test_field_52_main() {
     test_half();
     test_normalize_edge();
     test_commutativity_associativity();
+    test_conditional_negate_assign();
 
     (void)std::printf("\n=== Results: %d passed, %d failed ===\n",
                g_tests_passed, g_tests_failed);

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -26,6 +26,7 @@ services:
       - CCACHE_DIR=/ccache
       - CCACHE_MAXSIZE=5G
       - CCACHE_COMPRESS=1
+      - BENCH_MIN_RATIO=${BENCH_MIN_RATIO:-1.00}
     tmpfs:
       - /tmp:size=2G
 


### PR DESCRIPTION
## Summary

Add tests to increase new code coverage from 73.7% to ~84%, passing the SonarCloud Quality Gate (>= 80%).

### Changes

**cpu/tests/test_ct.cpp**:
- `test_ct_privatekey_ecdsa()`: Exercises `ct::ecdsa_sign` and `ct::ecdsa_sign_verified` with PrivateKey overloads
- `test_ct_privatekey_ecdsa_hedged()`: Exercises `ct::ecdsa_sign_hedged` and `ct::ecdsa_sign_hedged_verified` with PrivateKey overloads
- `test_ct_privatekey_schnorr()`: Exercises `ct::schnorr_pubkey` and `ct::schnorr_keypair_create` with PrivateKey overloads

**cpu/tests/test_field_52.cpp**:
- `test_conditional_negate_assign()`: Covers `FieldElement52::conditional_negate_assign()` branchless negate (mask=0 identity, mask=-1 negate, double-negate roundtrip, additive inverse)

**docker-compose.ci.yml**:
- Forward `BENCH_MIN_RATIO` env var from host to Docker containers (was silently ignored before)

### Coverage Impact
- ct/sign.hpp: 0% -> 100% (+18 lines)
- field_52_impl.hpp: +15 lines (conditional_negate_assign)
- Total: 33 previously uncovered lines now covered
- Projected: 73.7% -> ~84% on new code

Addresses SonarCloud Quality Gate failure on main.