### PR TITLE
Use scalar_mul_glv for batched scalar multiplications

### DIFF
--- a/metal/shaders/secp256k1_kernels.metal
+++ b/metal/shaders/secp256k1_kernels.metal
@@ -141,7 +141,7 @@ kernel void scalar_mul_batch(
     AffinePoint base = bases[tid];
     Scalar256 k = scalars[tid];
 
-    JacobianPoint jac = scalar_mul(base, k);
+    JacobianPoint jac = scalar_mul_glv(base, k);
     results[tid] = jacobian_to_affine(jac);
 }
 


### PR DESCRIPTION
This small change allows the Metal shader kernel to use the new `scalar_mul_glv`.
