### PR TITLE
fix: resolve 100 code-scanning alerts (braces, const, widening, init-vars)

### DIFF
--- a/audit/test_adversarial_protocol.cpp
+++ b/audit/test_adversarial_protocol.cpp
@@ -2529,7 +2529,7 @@ static void test_ffi_overlapping_buffers() {
 
     // Now use overlapping: input at overlap_buf, output at overlap_buf
     // The function should either work correctly or reject -- not crash
-    ufsecp_error_t rc = ufsecp_pubkey_create(ctx, overlap_buf, overlap_buf);
+    const ufsecp_error_t rc = ufsecp_pubkey_create(ctx, overlap_buf, overlap_buf);
     if (rc == UFSECP_OK) {
         // If it "worked", check result is valid (may or may not match reference
         // since input was overwritten partway through)

--- a/audit/test_ecies_regression.cpp
+++ b/audit/test_ecies_regression.cpp
@@ -153,10 +153,10 @@ static void test_ecies_truncated_envelope(ufsecp_ctx* ctx) {
     for (size_t sz : truncated_sizes) {
         size_t pt_len = 256;
         uint8_t pt_out[256];
-        ufsecp_error_t err = ufsecp_ecies_decrypt(ctx, TEST_PRIVKEY,
+        const ufsecp_error_t err = ufsecp_ecies_decrypt(ctx, TEST_PRIVKEY,
             junk, sz, pt_out, &pt_len);
         char msg[64];
-        std::snprintf(msg, sizeof(msg), "truncated len=%zu -> fails cleanly", sz);
+        (void)std::snprintf(msg, sizeof(msg), "truncated len=%zu -> fails cleanly", sz);
         CHECK(err != UFSECP_OK, msg);
     }
 }
@@ -185,15 +185,16 @@ static void test_ecies_tamper_matrix(ufsecp_ctx* ctx) {
 
     for (auto& f : fields) {
         auto tampered = envelope;
-        if (f.offset < tampered.size())
+        if (f.offset < tampered.size()) {
             tampered[f.offset] ^= 0x01; // flip one bit
+        }
 
         size_t pt_len = ct_len;
         std::vector<uint8_t> pt_out(pt_len);
-        ufsecp_error_t err = ufsecp_ecies_decrypt(ctx, TEST_PRIVKEY,
+        const ufsecp_error_t err = ufsecp_ecies_decrypt(ctx, TEST_PRIVKEY,
             tampered.data(), tampered.size(), pt_out.data(), &pt_len);
         char msg[80];
-        std::snprintf(msg, sizeof(msg), "tamper %s -> decrypt fails", f.name);
+        (void)std::snprintf(msg, sizeof(msg), "tamper %s -> decrypt fails", f.name);
         CHECK(err != UFSECP_OK, msg);
     }
 }
@@ -215,7 +216,7 @@ static void test_ecies_roundtrip_kat(ufsecp_ctx* ctx) {
     };
 
     for (const char* pt_str : test_vectors) {
-        size_t pt_len = std::strlen(pt_str);
+        const size_t pt_len = std::strlen(pt_str);
         size_t env_len = pt_len + UFSECP_ECIES_OVERHEAD;
         std::vector<uint8_t> envelope(env_len);
 
@@ -259,7 +260,7 @@ static void test_abi_prefix_rejection(ufsecp_ctx* ctx) {
     uint8_t good_pubkey33[33];
     get_pubkey(ctx, TEST_PRIVKEY, good_pubkey33);
 
-    for (uint8_t prefix : bad_prefixes) {
+    for (const uint8_t prefix : bad_prefixes) {
         uint8_t bad_pk[33];
         std::memcpy(bad_pk, good_pubkey33, 33);
         bad_pk[0] = prefix;
@@ -269,8 +270,8 @@ static void test_abi_prefix_rejection(ufsecp_ctx* ctx) {
         // F1: ufsecp_ecdh
         {
             uint8_t secret[32];
-            ufsecp_error_t err = ufsecp_ecdh(ctx, TEST_PRIVKEY2, bad_pk, secret);
-            std::snprintf(msg, sizeof(msg), "ecdh rejects prefix 0x%02X", prefix);
+            const ufsecp_error_t err = ufsecp_ecdh(ctx, TEST_PRIVKEY2, bad_pk, secret);
+            (void)std::snprintf(msg, sizeof(msg), "ecdh rejects prefix 0x%02X", prefix);
             CHECK(err == UFSECP_ERR_BAD_PUBKEY, msg);
         }
 
@@ -279,33 +280,33 @@ static void test_abi_prefix_rejection(ufsecp_ctx* ctx) {
             uint8_t pt[] = "test";
             size_t env_len = sizeof(pt) - 1 + UFSECP_ECIES_OVERHEAD;
             std::vector<uint8_t> env(env_len);
-            ufsecp_error_t err = ufsecp_ecies_encrypt(ctx, bad_pk, pt, sizeof(pt)-1,
+            const ufsecp_error_t err = ufsecp_ecies_encrypt(ctx, bad_pk, pt, sizeof(pt)-1,
                                                        env.data(), &env_len);
-            std::snprintf(msg, sizeof(msg), "ecies_encrypt rejects prefix 0x%02X", prefix);
+            (void)std::snprintf(msg, sizeof(msg), "ecies_encrypt rejects prefix 0x%02X", prefix);
             CHECK(err == UFSECP_ERR_BAD_PUBKEY, msg);
         }
 
         // F3: ufsecp_pubkey_parse (should reject or produce different error)
         {
             uint8_t parsed[33];
-            ufsecp_error_t err = ufsecp_pubkey_parse(ctx, bad_pk, 33, parsed);
-            std::snprintf(msg, sizeof(msg), "pubkey_parse rejects prefix 0x%02X", prefix);
+            const ufsecp_error_t err = ufsecp_pubkey_parse(ctx, bad_pk, 33, parsed);
+            (void)std::snprintf(msg, sizeof(msg), "pubkey_parse rejects prefix 0x%02X", prefix);
             CHECK(err != UFSECP_OK, msg);
         }
 
         // F4: ufsecp_ecdh_xonly
         {
             uint8_t secret[32];
-            ufsecp_error_t err = ufsecp_ecdh_xonly(ctx, TEST_PRIVKEY2, bad_pk, secret);
-            std::snprintf(msg, sizeof(msg), "ecdh_xonly rejects prefix 0x%02X", prefix);
+            const ufsecp_error_t err = ufsecp_ecdh_xonly(ctx, TEST_PRIVKEY2, bad_pk, secret);
+            (void)std::snprintf(msg, sizeof(msg), "ecdh_xonly rejects prefix 0x%02X", prefix);
             CHECK(err == UFSECP_ERR_BAD_PUBKEY, msg);
         }
 
         // F5: ufsecp_ecdh_raw
         {
             uint8_t secret[32];
-            ufsecp_error_t err = ufsecp_ecdh_raw(ctx, TEST_PRIVKEY2, bad_pk, secret);
-            std::snprintf(msg, sizeof(msg), "ecdh_raw rejects prefix 0x%02X", prefix);
+            const ufsecp_error_t err = ufsecp_ecdh_raw(ctx, TEST_PRIVKEY2, bad_pk, secret);
+            (void)std::snprintf(msg, sizeof(msg), "ecdh_raw rejects prefix 0x%02X", prefix);
             CHECK(err == UFSECP_ERR_BAD_PUBKEY, msg);
         }
     }
@@ -351,32 +352,32 @@ static void test_pubkey_parser_consistency(ufsecp_ctx* ctx) {
 
         // All endpoints must reject consistently
         uint8_t parsed[33];
-        ufsecp_error_t e_parse = ufsecp_pubkey_parse(ctx, bk, 33, parsed);
+        const ufsecp_error_t e_parse = ufsecp_pubkey_parse(ctx, bk, 33, parsed);
 
         uint8_t secret[32];
-        ufsecp_error_t e_ecdh = ufsecp_ecdh(ctx, TEST_PRIVKEY, bk, secret);
+        const ufsecp_error_t e_ecdh = ufsecp_ecdh(ctx, TEST_PRIVKEY, bk, secret);
 
         uint8_t pt[] = "x";
         size_t env_len = 1 + UFSECP_ECIES_OVERHEAD;
         std::vector<uint8_t> env(env_len);
-        ufsecp_error_t e_ecies = ufsecp_ecies_encrypt(ctx, bk, pt, 1,
+        const ufsecp_error_t e_ecies = ufsecp_ecies_encrypt(ctx, bk, pt, 1,
                                                        env.data(), &env_len);
 
         // All must fail (none should be UFSECP_OK)
-        std::snprintf(msg, sizeof(msg), "%s: pubkey_parse fails", names[i]);
+        (void)std::snprintf(msg, sizeof(msg), "%s: pubkey_parse fails", names[i]);
         CHECK(e_parse != UFSECP_OK, msg);
 
-        std::snprintf(msg, sizeof(msg), "%s: ecdh fails", names[i]);
+        (void)std::snprintf(msg, sizeof(msg), "%s: ecdh fails", names[i]);
         CHECK(e_ecdh != UFSECP_OK, msg);
 
-        std::snprintf(msg, sizeof(msg), "%s: ecies_encrypt fails", names[i]);
+        (void)std::snprintf(msg, sizeof(msg), "%s: ecies_encrypt fails", names[i]);
         CHECK(e_ecies != UFSECP_OK, msg);
 
         // Consistency: all should return same error category (BAD_PUBKEY)
-        std::snprintf(msg, sizeof(msg), "%s: ecdh returns BAD_PUBKEY", names[i]);
+        (void)std::snprintf(msg, sizeof(msg), "%s: ecdh returns BAD_PUBKEY", names[i]);
         CHECK(e_ecdh == UFSECP_ERR_BAD_PUBKEY, msg);
 
-        std::snprintf(msg, sizeof(msg), "%s: ecies returns BAD_PUBKEY", names[i]);
+        (void)std::snprintf(msg, sizeof(msg), "%s: ecies returns BAD_PUBKEY", names[i]);
         CHECK(e_ecies == UFSECP_ERR_BAD_PUBKEY, msg);
     }
 }
@@ -392,7 +393,7 @@ static void test_rng_fail_closed(ufsecp_ctx* ctx) {
     uint8_t pubkey33[33];
     get_pubkey(ctx, TEST_PRIVKEY, pubkey33);
 
-    pid_t pid = fork();
+    const pid_t pid = fork();
     if (pid == 0) {
         // Child: install seccomp-bpf filter that makes getrandom return ENOSYS
         struct sock_filter filter[] = {
@@ -466,7 +467,7 @@ int test_ecies_regression_run() {
 
 #ifdef STANDALONE_ECIES_REGRESSION
 int main() {
-    int fails = test_ecies_regression_run();
+    const int fails = test_ecies_regression_run();
     return fails ? 1 : 0;
 }
 #endif

--- a/cpu/src/bip32.cpp
+++ b/cpu/src/bip32.cpp
@@ -432,7 +432,7 @@ std::pair<ExtendedKey, bool> bip32_derive_path(const ExtendedKey& master,
             has_digit = true;
         }
         if (!has_digit) return {ExtendedKey{}, false};
-        uint32_t index = static_cast<uint32_t>(index64);
+        const auto index = static_cast<uint32_t>(index64);
 
         // Check for hardened marker
         bool hardened = false;

--- a/cpu/src/bip39.cpp
+++ b/cpu/src/bip39.cpp
@@ -205,8 +205,8 @@ bool bip39_validate(const std::string& mnemonic) {
 
     // Verify checksum
     auto hash = SHA256::hash(entropy, entropy_bytes);
-    uint8_t expected_cs = hash[0] >> (8 - checksum_bits);
-    uint8_t actual_cs = checksum_byte >> (8 - checksum_bits);
+    const uint8_t expected_cs = hash[0] >> (8 - checksum_bits);
+    const uint8_t actual_cs = checksum_byte >> (8 - checksum_bits);
 
     detail::secure_erase(entropy, sizeof(entropy));
     return expected_cs == actual_cs;
@@ -278,8 +278,8 @@ bip39_mnemonic_to_entropy(const std::string& mnemonic) {
 
     // Verify checksum
     auto hash = SHA256::hash(entropy, entropy_bytes);
-    uint8_t expected_cs = hash[0] >> (8 - checksum_bits);
-    uint8_t actual_cs = checksum_byte >> (8 - checksum_bits);
+    const uint8_t expected_cs = hash[0] >> (8 - checksum_bits);
+    const uint8_t actual_cs = checksum_byte >> (8 - checksum_bits);
 
     if (expected_cs != actual_cs) {
         detail::secure_erase(entropy, sizeof(entropy));

--- a/cpu/src/ecies.cpp
+++ b/cpu/src/ecies.cpp
@@ -100,7 +100,7 @@ struct AES256 {
 
         for (int i = 8; i < 60; ++i) {
             std::uint8_t tmp[4];
-            std::memcpy(tmp, W + (i - 1) * 4, 4);
+            std::memcpy(tmp, W + static_cast<std::size_t>(i - 1) * 4, 4);
 
             if (i % 8 == 0) {
                 std::uint8_t const t = tmp[0];
@@ -112,12 +112,14 @@ struct AES256 {
                 for (int j = 0; j < 4; ++j) tmp[j] = SBOX[tmp[j]];
             }
 
-            for (int j = 0; j < 4; ++j)
+            for (int j = 0; j < 4; ++j) {
                 W[i * 4 + j] = W[(i - 8) * 4 + j] ^ tmp[j];
+            }
         }
 
-        for (int r = 0; r < 15; ++r)
-            std::memcpy(round_keys[r], W + r * 16, 16);
+        for (int r = 0; r < 15; ++r) {
+            std::memcpy(round_keys[r], W + static_cast<std::size_t>(r) * 16, 16);
+        }
 
         secp256k1::detail::secure_erase(W, sizeof(W));
     }
@@ -135,7 +137,7 @@ struct AES256 {
             for (int i = 0; i < 16; ++i) state[i] = SBOX[state[i]];
 
             // ShiftRows
-            std::uint8_t t;
+            std::uint8_t t = 0;
             t = state[1]; state[1] = state[5]; state[5] = state[9];
             state[9] = state[13]; state[13] = t;
             t = state[2]; state[2] = state[10]; state[10] = t;
@@ -184,8 +186,9 @@ void aes256_ctr(const std::uint8_t key[32],
         aes.encrypt_block(counter, keystream);
 
         std::size_t const chunk = (len - pos < 16) ? (len - pos) : 16;
-        for (std::size_t i = 0; i < chunk; ++i)
+        for (std::size_t i = 0; i < chunk; ++i) {
             output[pos + i] = input[pos + i] ^ keystream[i];
+        }
 
         pos += chunk;
 
@@ -340,8 +343,9 @@ std::vector<std::uint8_t>
 ecies_decrypt(const Scalar& privkey,
               const std::uint8_t* envelope, std::size_t envelope_len) {
     // Minimum envelope: 33 (pubkey) + 16 (IV) + 1 (ciphertext) + 32 (HMAC) = 82
-    if (privkey.is_zero() || !envelope || envelope_len < 82)
+    if (privkey.is_zero() || !envelope || envelope_len < 82) {
         return {};
+    }
 
     std::size_t const ciphertext_len = envelope_len - 33 - 16 - 32;
 
@@ -372,8 +376,9 @@ ecies_decrypt(const Scalar& privkey,
 
     // Constant-time compare
     std::uint8_t diff = 0;
-    for (std::size_t i = 0; i < 32; ++i)
+    for (std::size_t i = 0; i < 32; ++i) {
         diff = static_cast<std::uint8_t>(diff | (expected_tag[i] ^ tag[i]));
+    }
     if (diff != 0) {
         secp256k1::detail::secure_erase(kdf.data(), 64);
         return {}; // Authentication failed

--- a/include/ufsecp/ufsecp_impl.cpp
+++ b/include/ufsecp/ufsecp_impl.cpp
@@ -1704,18 +1704,24 @@ ufsecp_error_t ufsecp_musig2_partial_sign(
       }
       auto qc = kagg.Q.to_compressed(); std::memcpy(kagg.Q_x.data(), qc.data() + 1, 32);
       for (uint32_t i = 0; i < nk && (38u + (i+1)*32u <= UFSECP_MUSIG2_KEYAGG_LEN); ++i) {
-          Scalar s; if (!scalar_parse_strict(keyagg + 38 + i * 32, s))
-              return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid key coefficient");
-          kagg.key_coefficients.push_back(s); } }
+          Scalar s;
+            if (!scalar_parse_strict(keyagg + 38 + static_cast<size_t>(i) * 32, s)) {
+                return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid key coefficient");
+            }
+            kagg.key_coefficients.push_back(s);
+        }
+    }
     secp256k1::MuSig2Session sess;
     sess.R = point_from_compressed(session);
     if (sess.R.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid session R point");
     }
-    if (!scalar_parse_strict(session + 33, sess.b))
+    if (!scalar_parse_strict(session + 33, sess.b)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid session scalar b");
-    if (!scalar_parse_strict(session + 65, sess.e))
+    }
+    if (!scalar_parse_strict(session + 65, sess.e)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid session scalar e");
+    }
     sess.R_negated = (session[97] != 0);
     auto psig = secp256k1::musig2_partial_sign(sn, sk, kagg, sess, signer_index);
     secp256k1::detail::secure_erase(&sk, sizeof(sk));
@@ -1753,18 +1759,24 @@ ufsecp_error_t ufsecp_musig2_partial_verify(
       }
       auto qc = kagg.Q.to_compressed(); std::memcpy(kagg.Q_x.data(), qc.data() + 1, 32);
       for (uint32_t i = 0; i < nk && (38u + (i+1)*32u <= UFSECP_MUSIG2_KEYAGG_LEN); ++i) {
-          Scalar s; if (!scalar_parse_strict(keyagg + 38 + i * 32, s))
-              return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid key coefficient");
-          kagg.key_coefficients.push_back(s); } }
+          Scalar s;
+            if (!scalar_parse_strict(keyagg + 38 + static_cast<size_t>(i) * 32, s)) {
+                return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid key coefficient");
+            }
+            kagg.key_coefficients.push_back(s);
+        }
+    }
     secp256k1::MuSig2Session sess;
     sess.R = point_from_compressed(session);
     if (sess.R.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid session R point");
     }
-    if (!scalar_parse_strict(session + 33, sess.b))
+    if (!scalar_parse_strict(session + 33, sess.b)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid session scalar b");
-    if (!scalar_parse_strict(session + 65, sess.e))
+    }
+    if (!scalar_parse_strict(session + 65, sess.e)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid session scalar e");
+    }
     sess.R_negated = (session[97] != 0);
     if (!secp256k1::musig2_partial_verify(psig, pn, pk_arr, kagg, sess, signer_index))
         return ctx_set_err(ctx, UFSECP_ERR_VERIFY_FAIL, "partial sig verify failed");
@@ -1788,10 +1800,12 @@ ufsecp_error_t ufsecp_musig2_partial_sig_agg(
     if (sess.R.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid session R point");
     }
-    if (!scalar_parse_strict(session + 33, sess.b))
+    if (!scalar_parse_strict(session + 33, sess.b)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid session scalar b");
-    if (!scalar_parse_strict(session + 65, sess.e))
+    }
+    if (!scalar_parse_strict(session + 65, sess.e)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid session scalar e");
+    }
     sess.R_negated = (session[97] != 0);
     auto final_sig = secp256k1::musig2_partial_sig_agg(psigs, sess);
     std::memcpy(sig64_out, final_sig.data(), 64);
@@ -1819,8 +1833,8 @@ ufsecp_error_t ufsecp_frost_keygen_begin(
         participant_id, threshold, num_participants, seed_arr);
     secp256k1::detail::secure_erase(seed_arr.data(), 32);
     /* Serialize commitment: coeff count(4) + from(4) + coeffs(33 each) */
-    size_t coeff_count = commit.coeffs.size();
-    size_t needed_commits = 8 + coeff_count * 33;
+    const size_t coeff_count = commit.coeffs.size();
+    const size_t needed_commits = 8 + coeff_count * 33;
     if (*commits_len < needed_commits)
         return ctx_set_err(ctx, UFSECP_ERR_BUF_TOO_SMALL, "commits buffer too small");
     uint32_t cc32 = static_cast<uint32_t>(coeff_count);
@@ -1842,8 +1856,9 @@ ufsecp_error_t ufsecp_frost_keygen_begin(
     }
     *shares_len = needed_shares;
     // Erase secret shares from memory
-    for (auto& s : shares)
+    for (auto& s : shares) {
         secp256k1::detail::secure_erase(&s.value, sizeof(s.value));
+    }
     return UFSECP_OK;
 }
 
@@ -1861,13 +1876,15 @@ ufsecp_error_t ufsecp_frost_keygen_finalize(
     size_t pos = 0;
     while (pos < commits_len) {
         secp256k1::FrostCommitment fc;
-        uint32_t cc;
-        if (pos + 8 > commits_len)
+        uint32_t cc = 0;
+        if (pos + 8 > commits_len) {
             return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "truncated commit header");
+        }
         std::memcpy(&cc, all_commits + pos, 4); pos += 4;
         std::memcpy(&fc.from, all_commits + pos, 4); pos += 4;
-        if (pos + static_cast<size_t>(cc) * 33 > commits_len)
+        if (pos + static_cast<size_t>(cc) * 33 > commits_len) {
             return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "truncated commit coefficients");
+        }
         for (uint32_t j = 0; j < cc; ++j) {
             auto pt = point_from_compressed(all_commits + pos);
             if (pt.is_infinity()) {
@@ -1886,17 +1903,20 @@ ufsecp_error_t ufsecp_frost_keygen_finalize(
         std::memcpy(&shares[i].from, s, 4);
         shares[i].id = participant_id;
         Scalar v;
-        if (!scalar_parse_strict(s + 4, v))
+        if (!scalar_parse_strict(s + 4, v)) {
             return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid share scalar");
+        }
         shares[i].value = v;
     }
     auto [kp, ok] = secp256k1::frost_keygen_finalize(
         participant_id, commits, shares, threshold, num_participants);
-    if (!ok)
+    if (!ok) {
         return ctx_set_err(ctx, UFSECP_ERR_INTERNAL, "FROST keygen finalize failed");
+    }
     // Erase secret shares
-    for (auto& s : shares)
+    for (auto& s : shares) {
         secp256k1::detail::secure_erase(&s.value, sizeof(s.value));
+    }
     /* Serialize FrostKeyPackage: id(4) | threshold(4) | num_participants(4) |
        signing_share(32) | verification_share(33) | group_public_key(33) = 110 bytes */
     std::memset(keypkg_out, 0, UFSECP_FROST_KEYPKG_LEN);
@@ -1952,8 +1972,9 @@ ufsecp_error_t ufsecp_frost_sign(
     std::memcpy(&kp.id, keypkg, 4);
     std::memcpy(&kp.threshold, keypkg + 4, 4);
     std::memcpy(&kp.num_participants, keypkg + 8, 4);
-    if (!scalar_parse_strict(keypkg + 12, kp.signing_share))
+    if (!scalar_parse_strict(keypkg + 12, kp.signing_share)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_KEY, "invalid signing share in keypkg");
+    }
     kp.verification_share = point_from_compressed(keypkg + 44);
     if (kp.verification_share.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_KEY, "invalid verification share");
@@ -1964,10 +1985,12 @@ ufsecp_error_t ufsecp_frost_sign(
     }
     secp256k1::FrostNonce fn;
     Scalar h, b;
-    if (!scalar_parse_strict(nonce, h))
+    if (!scalar_parse_strict(nonce, h)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid hiding nonce");
-    if (!scalar_parse_strict(nonce + 32, b))
+    }
+    if (!scalar_parse_strict(nonce + 32, b)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid binding nonce");
+    }
     fn.hiding_nonce = h;
     fn.binding_nonce = b;
     std::array<uint8_t, 32> msg_arr;
@@ -2003,14 +2026,16 @@ ufsecp_error_t ufsecp_frost_verify_partial(
     const uint8_t* nonce_commits, size_t n_signers,
     const uint8_t msg32[32],
     const uint8_t group_pubkey33[33]) {
-    if (!ctx || !partial_sig || !verification_share33 || !nonce_commits || !msg32 || !group_pubkey33)
+    if (!ctx || !partial_sig || !verification_share33 || !nonce_commits || !msg32 || !group_pubkey33) {
         return UFSECP_ERR_NULL_ARG;
+    }
     ctx_clear_err(ctx);
     secp256k1::FrostPartialSig psig;
     std::memcpy(&psig.id, partial_sig, 4);
     Scalar z;
-    if (!scalar_parse_strict(partial_sig + 4, z))
+    if (!scalar_parse_strict(partial_sig + 4, z)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_SIG, "invalid partial sig scalar");
+    }
     psig.z_i = z;
     auto vs = point_from_compressed(verification_share33);
     if (vs.is_infinity())
@@ -2054,16 +2079,18 @@ ufsecp_error_t ufsecp_frost_aggregate(
     const uint8_t group_pubkey33[33],
     const uint8_t msg32[32],
     uint8_t sig64_out[64]) {
-    if (!ctx || !partial_sigs || !nonce_commits || !group_pubkey33 || !msg32 || !sig64_out)
+    if (!ctx || !partial_sigs || !nonce_commits || !group_pubkey33 || !msg32 || !sig64_out) {
         return UFSECP_ERR_NULL_ARG;
+    }
     ctx_clear_err(ctx);
     std::vector<secp256k1::FrostPartialSig> psigs(n);
     for (size_t i = 0; i < n; ++i) {
         const uint8_t* ps = partial_sigs + i * 36;
         std::memcpy(&psigs[i].id, ps, 4);
         Scalar z;
-        if (!scalar_parse_strict(ps + 4, z))
+        if (!scalar_parse_strict(ps + 4, z)) {
             return ctx_set_err(ctx, UFSECP_ERR_BAD_SIG, "invalid partial sig scalar");
+        }
         psigs[i].z_i = z;
     }
     std::vector<secp256k1::FrostNonceCommitment> ncs(n_signers);
@@ -2141,14 +2168,16 @@ ufsecp_error_t ufsecp_schnorr_adaptor_verify(
         return ctx_set_err(ctx, UFSECP_ERR_BAD_SIG, "invalid adaptor R_hat");
     }
     Scalar shat;
-    if (!scalar_parse_strict(pre_sig + 33, shat))
+    if (!scalar_parse_strict(pre_sig + 33, shat)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_SIG, "invalid adaptor sig scalar");
+    }
     as.s_hat = shat;
     as.needs_negation = (pre_sig[65] != 0);
     // Strict: reject x-only pubkey >= p at ABI gate
     FE pk_fe;
-    if (!FE::parse_bytes_strict(pubkey_x, pk_fe))
+    if (!FE::parse_bytes_strict(pubkey_x, pk_fe)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "non-canonical pubkey (x>=p)");
+    }
     std::array<uint8_t, 32> pk_arr, msg_arr;
     std::memcpy(pk_arr.data(), pubkey_x, 32);
     std::memcpy(msg_arr.data(), msg32, 32);
@@ -2173,8 +2202,9 @@ ufsecp_error_t ufsecp_schnorr_adaptor_adapt(
         return ctx_set_err(ctx, UFSECP_ERR_BAD_SIG, "invalid adaptor R_hat");
     }
     Scalar shat;
-    if (!scalar_parse_strict(pre_sig + 33, shat))
+    if (!scalar_parse_strict(pre_sig + 33, shat)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_SIG, "invalid adaptor sig scalar");
+    }
     as.s_hat = shat;
     as.needs_negation = (pre_sig[65] != 0);
     Scalar secret;
@@ -2200,8 +2230,9 @@ ufsecp_error_t ufsecp_schnorr_adaptor_extract(
         return ctx_set_err(ctx, UFSECP_ERR_BAD_SIG, "invalid adaptor R_hat");
     }
     Scalar shat;
-    if (!scalar_parse_strict(pre_sig + 33, shat))
+    if (!scalar_parse_strict(pre_sig + 33, shat)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_SIG, "invalid adaptor sig scalar");
+    }
     as.s_hat = shat;
     as.needs_negation = (pre_sig[65] != 0);
     secp256k1::SchnorrSignature sig;
@@ -2807,15 +2838,18 @@ ufsecp_error_t ufsecp_silent_payment_address(
     uint8_t spend_pubkey33_out[33],
     char* addr_out, size_t* addr_len) {
     if (!ctx || !scan_privkey || !spend_privkey || !scan_pubkey33_out ||
-        !spend_pubkey33_out || !addr_out || !addr_len)
+        !spend_pubkey33_out || !addr_out || !addr_len) {
         return UFSECP_ERR_NULL_ARG;
+    }
     ctx_clear_err(ctx);
 
     Scalar scan_sk, spend_sk;
-    if (!scalar_parse_strict_nonzero(scan_privkey, scan_sk))
+    if (!scalar_parse_strict_nonzero(scan_privkey, scan_sk)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_KEY, "scan privkey is zero or >= n");
-    if (!scalar_parse_strict_nonzero(spend_privkey, spend_sk))
+    }
+    if (!scalar_parse_strict_nonzero(spend_privkey, spend_sk)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_KEY, "spend privkey is zero or >= n");
+    }
 
     auto spa = secp256k1::silent_payment_address(scan_sk, spend_sk);
     auto scan_comp  = spa.scan_pubkey.to_compressed();
@@ -2824,8 +2858,9 @@ ufsecp_error_t ufsecp_silent_payment_address(
     std::memcpy(spend_pubkey33_out, spend_comp.data(), 33);
 
     auto addr_str = spa.encode();
-    if (addr_str.size() >= *addr_len)
+    if (addr_str.size() >= *addr_len) {
         return ctx_set_err(ctx, UFSECP_ERR_BUF_TOO_SMALL, "address buffer too small");
+    }
     std::memcpy(addr_out, addr_str.c_str(), addr_str.size() + 1);
     *addr_len = addr_str.size();
 
@@ -2843,8 +2878,9 @@ ufsecp_error_t ufsecp_silent_payment_create_output(
     uint8_t output_pubkey33_out[33],
     uint8_t* tweak32_out) {
     if (!ctx || !input_privkeys || n_inputs == 0 || !scan_pubkey33 ||
-        !spend_pubkey33 || !output_pubkey33_out)
+        !spend_pubkey33 || !output_pubkey33_out) {
         return UFSECP_ERR_NULL_ARG;
+    }
     ctx_clear_err(ctx);
 
     // Parse input private keys
@@ -2852,8 +2888,9 @@ ufsecp_error_t ufsecp_silent_payment_create_output(
     privkeys.reserve(n_inputs);
     for (size_t i = 0; i < n_inputs; ++i) {
         Scalar sk;
-        if (!scalar_parse_strict_nonzero(input_privkeys + i * 32, sk))
+        if (!scalar_parse_strict_nonzero(input_privkeys + i * 32, sk)) {
             return ctx_set_err(ctx, UFSECP_ERR_BAD_KEY, "input privkey is zero or >= n");
+        }
         privkeys.push_back(sk);
     }
 
@@ -2861,12 +2898,14 @@ ufsecp_error_t ufsecp_silent_payment_create_output(
     secp256k1::SilentPaymentAddress recipient;
     recipient.scan_pubkey = point_from_compressed(scan_pubkey33);
     recipient.spend_pubkey = point_from_compressed(spend_pubkey33);
-    if (recipient.scan_pubkey.is_infinity() || recipient.spend_pubkey.is_infinity())
+    if (recipient.scan_pubkey.is_infinity() || recipient.spend_pubkey.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "invalid recipient pubkey");
+    }
 
     auto [output_point, tweak] = secp256k1::silent_payment_create_output(privkeys, recipient, k);
-    if (output_point.is_infinity())
+    if (output_point.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_ARITH, "output point is infinity");
+    }
 
     auto out_comp = output_point.to_compressed();
     std::memcpy(output_pubkey33_out, out_comp.data(), 33);
@@ -2876,8 +2915,9 @@ ufsecp_error_t ufsecp_silent_payment_create_output(
         std::memcpy(tweak32_out, tweak_bytes.data(), 32);
     }
 
-    for (auto& sk : privkeys)
+    for (auto& sk : privkeys) {
         secp256k1::detail::secure_erase(&sk, sizeof(sk));
+    }
     return UFSECP_OK;
 }
 
@@ -2891,25 +2931,30 @@ ufsecp_error_t ufsecp_silent_payment_scan(
     uint8_t* found_privkeys_out,
     size_t* n_found) {
     if (!ctx || !scan_privkey || !spend_privkey || !input_pubkeys33 ||
-        !output_xonly32 || !n_found)
+        !output_xonly32 || !n_found) {
         return UFSECP_ERR_NULL_ARG;
-    if (n_input_pubkeys == 0 || n_outputs == 0)
+    }
+    if (n_input_pubkeys == 0 || n_outputs == 0) {
         return UFSECP_ERR_BAD_INPUT;
+    }
     ctx_clear_err(ctx);
 
     Scalar scan_sk, spend_sk;
-    if (!scalar_parse_strict_nonzero(scan_privkey, scan_sk))
+    if (!scalar_parse_strict_nonzero(scan_privkey, scan_sk)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_KEY, "scan privkey is zero or >= n");
-    if (!scalar_parse_strict_nonzero(spend_privkey, spend_sk))
+    }
+    if (!scalar_parse_strict_nonzero(spend_privkey, spend_sk)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_KEY, "spend privkey is zero or >= n");
+    }
 
     // Parse input pubkeys
     std::vector<Point> input_pks;
     input_pks.reserve(n_input_pubkeys);
     for (size_t i = 0; i < n_input_pubkeys; ++i) {
         auto pk = point_from_compressed(input_pubkeys33 + i * 33);
-        if (pk.is_infinity())
+        if (pk.is_infinity()) {
             return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "invalid input pubkey");
+        }
         input_pks.push_back(pk);
     }
 
@@ -2950,8 +2995,9 @@ ufsecp_error_t ufsecp_ecies_encrypt(
     const uint8_t recipient_pubkey33[33],
     const uint8_t* plaintext, size_t plaintext_len,
     uint8_t* envelope_out, size_t* envelope_len) {
-    if (!ctx || !recipient_pubkey33 || !plaintext || !envelope_out || !envelope_len)
+    if (!ctx || !recipient_pubkey33 || !plaintext || !envelope_out || !envelope_len) {
         return UFSECP_ERR_NULL_ARG;
+    }
     if (plaintext_len == 0) {
         return UFSECP_ERR_BAD_INPUT;
     }
@@ -2961,16 +3007,19 @@ ufsecp_error_t ufsecp_ecies_encrypt(
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "plaintext_len too large");
     }
     size_t const needed = plaintext_len + UFSECP_ECIES_OVERHEAD;
-    if (*envelope_len < needed)
+    if (*envelope_len < needed) {
         return ctx_set_err(ctx, UFSECP_ERR_BUF_TOO_SMALL, "envelope buffer too small");
+    }
 
     auto pk = point_from_compressed(recipient_pubkey33);
-    if (pk.is_infinity())
+    if (pk.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "invalid recipient pubkey");
+    }
 
     auto envelope = secp256k1::ecies_encrypt(pk, plaintext, plaintext_len);
-    if (envelope.empty())
+    if (envelope.empty()) {
         return ctx_set_err(ctx, UFSECP_ERR_INTERNAL, "ECIES encryption failed");
+    }
 
     std::memcpy(envelope_out, envelope.data(), envelope.size());
     *envelope_len = envelope.size();
@@ -2982,25 +3031,30 @@ ufsecp_error_t ufsecp_ecies_decrypt(
     const uint8_t privkey[32],
     const uint8_t* envelope, size_t envelope_len,
     uint8_t* plaintext_out, size_t* plaintext_len) {
-    if (!ctx || !privkey || !envelope || !plaintext_out || !plaintext_len)
+    if (!ctx || !privkey || !envelope || !plaintext_out || !plaintext_len) {
         return UFSECP_ERR_NULL_ARG;
-    if (envelope_len < 82) // min: 33 + 16 + 1 + 32
+    }
+    if (envelope_len < 82) { // min: 33 + 16 + 1 + 32
         return UFSECP_ERR_BAD_INPUT;
+    }
     ctx_clear_err(ctx);
 
     size_t const expected_pt_len = envelope_len - UFSECP_ECIES_OVERHEAD;
-    if (*plaintext_len < expected_pt_len)
+    if (*plaintext_len < expected_pt_len) {
         return ctx_set_err(ctx, UFSECP_ERR_BUF_TOO_SMALL, "plaintext buffer too small");
+    }
 
     Scalar sk;
-    if (!scalar_parse_strict_nonzero(privkey, sk))
+    if (!scalar_parse_strict_nonzero(privkey, sk)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_KEY, "privkey is zero or >= n");
+    }
 
     auto pt = secp256k1::ecies_decrypt(sk, envelope, envelope_len);
     secp256k1::detail::secure_erase(&sk, sizeof(sk));
 
-    if (pt.empty())
+    if (pt.empty()) {
         return ctx_set_err(ctx, UFSECP_ERR_VERIFY_FAIL, "ECIES decryption failed (bad key or tampered)");
+    }
 
     std::memcpy(plaintext_out, pt.data(), pt.size());
     *plaintext_len = pt.size();


### PR DESCRIPTION
## Summary

Fixes all 100 open code-scanning alerts across 6 files.

| Rule | Count | Files |
|------|-------|-------|
| `readability-braces-around-statements` | 59 | `ufsecp_impl.cpp`, `ecies.cpp` |
| `misc-const-correctness` | 21 | `ufsecp_impl.cpp`, `test_ecies_regression.cpp`, `bip39.cpp`, `test_adversarial_protocol.cpp` |
| `cert-err33-c` | 12 | `test_ecies_regression.cpp` |
| `bugprone-implicit-widening-of-multiplication-result` | 5 | `ufsecp_impl.cpp`, `ecies.cpp` |
| `cppcoreguidelines-init-variables` | 2 | `ufsecp_impl.cpp`, `ecies.cpp` |
| `modernize-use-auto` | 1 | `bip32.cpp` |

## Changes

- `include/ufsecp/ufsecp_impl.cpp` — 59 alerts (musig2, FROST, adaptor sig, silent payments, ECIES C-ABI sections)
- `audit/test_ecies_regression.cpp` — 27 alerts
- `cpu/src/ecies.cpp` — 8 alerts
- `cpu/src/bip39.cpp` — 3 alerts
- `cpu/src/bip32.cpp` — 2 alerts
- `audit/test_adversarial_protocol.cpp` — 1 alert

No functional changes — purely style/diagnostic conformance fixes.