### PR TITLE
fix: resolve 50 code-scanning alerts (braces, const, widening, init-vars, argumentSize)

### DIFF
--- a/audit/test_adversarial_protocol.cpp
+++ b/audit/test_adversarial_protocol.cpp
@@ -36,9 +36,14 @@ static int g_pass = 0, g_fail = 0;
 
 static void hex_to_bytes(const char* hex, uint8_t* out, int len) {
     for (int i = 0; i < len; ++i) {
-        unsigned byte = 0;
-        if (std::sscanf(hex + static_cast<size_t>(i) * 2, "%02x", &byte) != 1) byte = 0;
-        out[i] = static_cast<uint8_t>(byte);
+        char pair[3] = {
+            hex[static_cast<size_t>(i) * 2],
+            hex[static_cast<size_t>(i) * 2 + 1],
+            '\0'
+        };
+        char* endptr = nullptr;
+        const unsigned long val = std::strtoul(pair, &endptr, 16);
+        out[i] = (endptr == pair + 2) ? static_cast<uint8_t>(val) : 0;
     }
 }
 
@@ -102,12 +107,12 @@ static void test_musig2_nonce_reuse() {
 
     // First sign -- should succeed
     uint8_t psig1[32];
-    ufsecp_error_t rc1 = ufsecp_musig2_partial_sign(ctx, secnonce1, priv1, keyagg, session, 0, psig1);
+    const ufsecp_error_t rc1 = ufsecp_musig2_partial_sign(ctx, secnonce1, priv1, keyagg, session, 0, psig1);
     CHECK_OK(rc1, "first partial_sign should succeed");
 
     // Second sign with SAME secnonce -- should fail (nonce was consumed)
     uint8_t psig1_dup[32];
-    ufsecp_error_t rc2 = ufsecp_musig2_partial_sign(ctx, secnonce1, priv1, keyagg, session, 0, psig1_dup);
+    const ufsecp_error_t rc2 = ufsecp_musig2_partial_sign(ctx, secnonce1, priv1, keyagg, session, 0, psig1_dup);
     CHECK(rc2 != UFSECP_OK, "reuse of consumed secnonce must fail");
 
     ufsecp_ctx_destroy(ctx);
@@ -177,7 +182,7 @@ static void test_musig2_partial_sig_replay() {
     ufsecp_musig2_start_sign_session(ctx, aggnonce2, keyagg, msg2, session2);
 
     // Replay: verify psig1 (from session1) under session2 -- must fail
-    ufsecp_error_t rc = ufsecp_musig2_partial_verify(ctx, psig1, pn1b, xonly1,
+    const ufsecp_error_t rc = ufsecp_musig2_partial_verify(ctx, psig1, pn1b, xonly1,
                                                       keyagg, session2, 0);
     CHECK(rc != UFSECP_OK, "replayed partial sig from session1 rejected in session2");
 
@@ -192,7 +197,7 @@ static void test_musig2_partial_sig_replay() {
     ufsecp_musig2_partial_sig_agg(ctx, psigs_mixed, 2, session2, final_sig);
 
     // Aggregated sig with replayed partial should NOT verify
-    ufsecp_error_t vrc = ufsecp_schnorr_verify(ctx, msg2, final_sig, agg_pub);
+    const ufsecp_error_t vrc = ufsecp_schnorr_verify(ctx, msg2, final_sig, agg_pub);
     CHECK(vrc != UFSECP_OK, "aggregated sig with replayed partial is invalid");
 
     ufsecp_ctx_destroy(ctx);
@@ -620,7 +625,7 @@ static void test_frost_below_threshold() {
         for (uint32_t j = 0; j < 3; ++j) {
             // Share j->i is at offset i*UFSECP_FROST_SHARE_LEN in shares[j]
             std::memcpy(recv_shares + recv_len,
-                        shares[j] + i * UFSECP_FROST_SHARE_LEN,
+                        shares[j] + static_cast<size_t>(i) * UFSECP_FROST_SHARE_LEN,
                         UFSECP_FROST_SHARE_LEN);
             recv_len += UFSECP_FROST_SHARE_LEN;
         }
@@ -647,14 +652,14 @@ static void test_frost_below_threshold() {
 
     // Try to produce partial sig with n_signers=1 (but threshold=2)
     uint8_t psig1[36];
-    ufsecp_error_t rc = ufsecp_frost_sign(ctx, keypkgs[0], nonce1, msg32,
+    const ufsecp_error_t rc = ufsecp_frost_sign(ctx, keypkgs[0], nonce1, msg32,
                                            ncommit1, 1, psig1);
 
     // Even if partial_sign succeeds, aggregation with 1 signer should produce
     // a signature that does NOT verify as valid Schnorr
     if (rc == UFSECP_OK) {
         uint8_t final_sig[64];
-        ufsecp_error_t arc = ufsecp_frost_aggregate(ctx, psig1, 1,
+        const ufsecp_error_t arc = ufsecp_frost_aggregate(ctx, psig1, 1,
                                                      ncommit1, 1,
                                                      group_pub, msg32, final_sig);
         if (arc == UFSECP_OK) {
@@ -704,7 +709,7 @@ static void test_frost_malformed_commitment() {
         uint8_t recv_shares[512]; size_t recv_len = 0;
         for (uint32_t j = 0; j < 3; ++j) {
             std::memcpy(recv_shares + recv_len,
-                        shares[j] + i * UFSECP_FROST_SHARE_LEN,
+                        shares[j] + static_cast<size_t>(i) * UFSECP_FROST_SHARE_LEN,
                         UFSECP_FROST_SHARE_LEN);
             recv_len += UFSECP_FROST_SHARE_LEN;
         }
@@ -737,7 +742,7 @@ static void test_frost_malformed_commitment() {
 
     // Signer 1 tries to sign with the corrupted ncommit set
     uint8_t psig1[36];
-    ufsecp_error_t rc = ufsecp_frost_sign(ctx, keypkgs[0], nonce1, msg32,
+    const ufsecp_error_t rc = ufsecp_frost_sign(ctx, keypkgs[0], nonce1, msg32,
                                            ncommits_bad, 2, psig1);
     // Either sign fails or the aggregated result won't verify
     if (rc == UFSECP_OK) {
@@ -749,7 +754,7 @@ static void test_frost_malformed_commitment() {
         std::memcpy(psigs_all, psig1, 36);
         std::memcpy(psigs_all + 36, psig2, 36);
         uint8_t final_sig[64];
-        ufsecp_error_t arc = ufsecp_frost_aggregate(ctx, psigs_all, 2,
+        const ufsecp_error_t arc = ufsecp_frost_aggregate(ctx, psigs_all, 2,
                                                      ncommits_bad, 2,
                                                      group_pub, msg32, final_sig);
         if (arc == UFSECP_OK) {
@@ -777,7 +782,8 @@ static void test_frost_hostile_args() {
     uint8_t nonce[UFSECP_FROST_NONCE_LEN] = {};
     uint8_t ncommit[UFSECP_FROST_NONCE_COMMIT_LEN] = {};
     uint8_t psig[36] = {};
-    size_t commits_len = sizeof(buf), shares_len = sizeof(buf);
+    size_t commits_len = sizeof(buf);
+    size_t shares_len  = commits_len;
 
     // keygen_begin: null ctx
     CHECK(ufsecp_frost_keygen_begin(nullptr, 1, 2, 3, buf,
@@ -1371,7 +1377,7 @@ static void test_sp_duplicate_sender_keys() {
 
     uint8_t out[33], tweak[32];
     // Should either reject or handle gracefully (no crash)
-    ufsecp_error_t rc = ufsecp_silent_payment_create_output(ctx, dup_privs, 2,
+    const ufsecp_error_t rc = ufsecp_silent_payment_create_output(ctx, dup_privs, 2,
           sp_scan33, sp_spend33, 0, out, tweak);
     // We just verify no crash; the result should differ from single-key output
     uint8_t out_single[33], tweak_single[32];
@@ -1481,7 +1487,7 @@ static void test_ecdsa_adaptor_round_trip() {
     CHECK_OK(ufsecp_pubkey_create(ctx, extracted, ext_point), "pubkey from extracted");
     uint8_t neg_point[33];
     CHECK_OK(ufsecp_pubkey_negate(ctx, ext_point, neg_point), "negate extracted");
-    bool match = (std::memcmp(ext_point, adaptor_point, 33) == 0) ||
+    const bool match = (std::memcmp(ext_point, adaptor_point, 33) == 0) ||
                  (std::memcmp(neg_point, adaptor_point, 33) == 0);
     CHECK(match, "extracted adaptor secret matches original (or negation)");
 
@@ -1557,7 +1563,7 @@ static void test_ecdsa_adaptor_wrong_point() {
     uint8_t wrong_point[33];
     ufsecp_pubkey_create(ctx, wrong_secret, wrong_point);
 
-    ufsecp_error_t rc = ufsecp_ecdsa_adaptor_verify(ctx, pre_sig, pub33, msg32, wrong_point);
+    const ufsecp_error_t rc = ufsecp_ecdsa_adaptor_verify(ctx, pre_sig, pub33, msg32, wrong_point);
     CHECK(rc != UFSECP_OK, "ecdsa_adaptor_verify rejects wrong adaptor point");
 
     ufsecp_ctx_destroy(ctx);
@@ -1741,7 +1747,7 @@ static void test_schnorr_adaptor_wrong_point() {
     uint8_t wrong_point[33];
     ufsecp_pubkey_create(ctx, wrong_secret, wrong_point);
 
-    ufsecp_error_t rc = ufsecp_schnorr_adaptor_verify(ctx, pre_sig, xonly, msg32, wrong_point);
+    const ufsecp_error_t rc = ufsecp_schnorr_adaptor_verify(ctx, pre_sig, xonly, msg32, wrong_point);
     CHECK(rc != UFSECP_OK, "schnorr_adaptor_verify rejects wrong adaptor point");
 
     ufsecp_ctx_destroy(ctx);
@@ -1774,11 +1780,11 @@ static void test_schnorr_adaptor_wrong_secret() {
     uint8_t wrong_secret[32] = {};
     wrong_secret[31] = 5;
     uint8_t bad_sig[64];
-    ufsecp_error_t rc = ufsecp_schnorr_adaptor_adapt(ctx, pre_sig, wrong_secret, bad_sig);
+    const ufsecp_error_t rc = ufsecp_schnorr_adaptor_adapt(ctx, pre_sig, wrong_secret, bad_sig);
 
     if (rc == UFSECP_OK) {
         // Adapted with wrong secret should produce invalid Schnorr sig
-        ufsecp_error_t vrc = ufsecp_schnorr_verify(ctx, msg32, bad_sig, xonly);
+        const ufsecp_error_t vrc = ufsecp_schnorr_verify(ctx, msg32, bad_sig, xonly);
         CHECK(vrc != UFSECP_OK, "schnorr sig adapted with wrong secret must not verify");
     } else {
         CHECK(true, "adapt with wrong secret correctly rejected");
@@ -2129,8 +2135,8 @@ static void test_hostile_taproot() {
     ufsecp_ctx_create(&ctx);
 
     uint8_t buf[64] = {};
-    uint8_t out[32];
-    int parity;
+    uint8_t out[32] = {};
+    int parity = 0;
 
     // output_key: null ctx
     CHECK(ufsecp_taproot_output_key(nullptr, buf, buf, out, &parity) != UFSECP_OK,
@@ -2267,7 +2273,7 @@ static void test_hostile_wif() {
 
     char wif[64]; size_t wif_len = sizeof(wif);
     uint8_t priv[32] = {};
-    int compressed_out, network_out;
+    int compressed_out = 0, network_out = 0;
 
     // wif_encode: null ctx
     CHECK(ufsecp_wif_encode(nullptr, priv, 1, 0, wif, &wif_len) != UFSECP_OK,
@@ -2400,7 +2406,7 @@ static void test_hostile_multi_coin() {
     ufsecp_ctx_create(&ctx);
 
     char addr[128]; size_t addr_len = sizeof(addr);
-    uint8_t priv[32] = {};
+    uint8_t priv[33] = {};
 
     // coin_address: null ctx
     CHECK(ufsecp_coin_address(nullptr, priv, 0, 0, addr, &addr_len) != UFSECP_OK,
@@ -2435,7 +2441,7 @@ static void test_hostile_ethereum() {
     // eth_address: null ctx
     CHECK(ufsecp_eth_address(nullptr, buf, out) != UFSECP_OK, "eth_address null ctx");
     // eth_sign: null ctx
-    uint8_t r[32], s[32]; uint64_t v;
+    uint8_t r[32] = {}, s[32] = {}; uint64_t v = 0;
     CHECK(ufsecp_eth_sign(nullptr, buf, buf, r, s, &v, 1) != UFSECP_OK, "eth_sign null ctx");
     // eth_ecrecover: null ctx
     uint8_t addr20[20];

--- a/audit/test_ecies_regression.cpp
+++ b/audit/test_ecies_regression.cpp
@@ -67,11 +67,11 @@ static void get_pubkey(ufsecp_ctx* ctx, const uint8_t privkey[32], uint8_t pubke
 // Create a valid ECIES envelope for subsequent tamper tests
 static std::vector<uint8_t> make_valid_envelope(ufsecp_ctx* ctx, const uint8_t pubkey33[33]) {
     const uint8_t plaintext[] = "ECIES regression test payload";
-    size_t pt_len = sizeof(plaintext) - 1; // exclude null
+    const size_t pt_len = sizeof(plaintext) - 1; // exclude null
     size_t env_len = pt_len + UFSECP_ECIES_OVERHEAD;
     std::vector<uint8_t> envelope(env_len);
 
-    ufsecp_error_t err = ufsecp_ecies_encrypt(ctx, pubkey33, plaintext, pt_len,
+    const ufsecp_error_t err = ufsecp_ecies_encrypt(ctx, pubkey33, plaintext, pt_len,
                                                envelope.data(), &env_len);
     if (err != UFSECP_OK) envelope.clear();
     return envelope;
@@ -93,7 +93,7 @@ static void test_ecies_parity_tamper(ufsecp_ctx* ctx) {
     {
         size_t pt_len = envelope.size() - UFSECP_ECIES_OVERHEAD;
         std::vector<uint8_t> pt_out(pt_len);
-        ufsecp_error_t err = ufsecp_ecies_decrypt(ctx, TEST_PRIVKEY,
+        const ufsecp_error_t err = ufsecp_ecies_decrypt(ctx, TEST_PRIVKEY,
             envelope.data(), envelope.size(), pt_out.data(), &pt_len);
         CHECK(err == UFSECP_OK, "untampered decrypt OK");
     }
@@ -105,7 +105,7 @@ static void test_ecies_parity_tamper(ufsecp_ctx* ctx) {
     {
         size_t pt_len = tampered.size() - UFSECP_ECIES_OVERHEAD;
         std::vector<uint8_t> pt_out(pt_len);
-        ufsecp_error_t err = ufsecp_ecies_decrypt(ctx, TEST_PRIVKEY,
+        const ufsecp_error_t err = ufsecp_ecies_decrypt(ctx, TEST_PRIVKEY,
             tampered.data(), tampered.size(), pt_out.data(), &pt_len);
         CHECK(err != UFSECP_OK, "parity-flipped ephemeral pubkey -> decrypt fails");
     }
@@ -124,16 +124,16 @@ static void test_ecies_invalid_prefix(ufsecp_ctx* ctx) {
     CHECK(!envelope.empty(), "valid envelope created for prefix test");
 
     const uint8_t bad_prefixes[] = {0x00, 0x04, 0xFF};
-    for (uint8_t prefix : bad_prefixes) {
+    for (const uint8_t prefix : bad_prefixes) {
         auto tampered = envelope;
         tampered[0] = prefix;
 
         size_t pt_len = tampered.size() - UFSECP_ECIES_OVERHEAD;
         std::vector<uint8_t> pt_out(pt_len);
-        ufsecp_error_t err = ufsecp_ecies_decrypt(ctx, TEST_PRIVKEY,
+        const ufsecp_error_t err = ufsecp_ecies_decrypt(ctx, TEST_PRIVKEY,
             tampered.data(), tampered.size(), pt_out.data(), &pt_len);
         char msg[64];
-        std::snprintf(msg, sizeof(msg), "prefix 0x%02X -> decrypt fails", prefix);
+        (void)std::snprintf(msg, sizeof(msg), "prefix 0x%02X -> decrypt fails", prefix);
         CHECK(err != UFSECP_OK, msg);
     }
 }
@@ -150,7 +150,7 @@ static void test_ecies_truncated_envelope(ufsecp_ctx* ctx) {
     // Put a valid-looking compressed prefix to avoid prefix rejection before length check
     junk[0] = 0x02;
 
-    for (size_t sz : truncated_sizes) {
+    for (const size_t sz : truncated_sizes) {
         size_t pt_len = 256;
         uint8_t pt_out[256];
         const ufsecp_error_t err = ufsecp_ecies_decrypt(ctx, TEST_PRIVKEY,

--- a/include/ufsecp/ufsecp_impl.cpp
+++ b/include/ufsecp/ufsecp_impl.cpp
@@ -931,8 +931,9 @@ ufsecp_error_t ufsecp_addr_p2pkh(ufsecp_ctx* ctx,
     ctx_clear_err(ctx);
 
     auto pk = point_from_compressed(pubkey33);
-    if (pk.is_infinity())
+    if (pk.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "invalid pubkey");
+    }
     auto addr = secp256k1::address_p2pkh(pk, to_network(network));
     if (addr.empty()) {
         return ctx_set_err(ctx, UFSECP_ERR_INTERNAL, "P2PKH generation failed");
@@ -1377,10 +1378,12 @@ ufsecp_error_t ufsecp_bip39_to_entropy(ufsecp_ctx* ctx,
     if (!ctx || !mnemonic || !entropy_out || !entropy_len) return UFSECP_ERR_NULL_ARG;
     ctx_clear_err(ctx);
     auto [ent, ok] = secp256k1::bip39_mnemonic_to_entropy(std::string(mnemonic));
-    if (!ok)
+    if (!ok) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid mnemonic");
-    if (*entropy_len < ent.length)
+    }
+    if (*entropy_len < ent.length) {
         return ctx_set_err(ctx, UFSECP_ERR_BUF_TOO_SMALL, "entropy buffer too small");
+    }
     std::memcpy(entropy_out, ent.data.data(), ent.length);
     *entropy_len = ent.length;
     return UFSECP_OK;
@@ -1401,8 +1404,9 @@ ufsecp_error_t ufsecp_schnorr_batch_verify(ufsecp_ctx* ctx,
         const uint8_t* e = entries + i * 128;
         // Strict: reject x-only pubkey >= p at ABI gate
         FE pk_fe;
-        if (!FE::parse_bytes_strict(e, pk_fe))
+        if (!FE::parse_bytes_strict(e, pk_fe)) {
             return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "non-canonical pubkey (x>=p) in batch");
+        }
         std::memcpy(batch[i].pubkey_x.data(), e, 32);
         std::memcpy(batch[i].message.data(), e + 32, 32);
         if (!secp256k1::SchnorrSignature::parse_strict(e + 64, batch[i].signature))
@@ -1445,8 +1449,9 @@ ufsecp_error_t ufsecp_schnorr_batch_identify_invalid(
     for (size_t i = 0; i < n; ++i) {
         const uint8_t* e = entries + i * 128;
         FE pk_fe;
-        if (!FE::parse_bytes_strict(e, pk_fe))
+        if (!FE::parse_bytes_strict(e, pk_fe)) {
             return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "non-canonical pubkey (x>=p) in batch");
+        }
         std::memcpy(batch[i].pubkey_x.data(), e, 32);
         std::memcpy(batch[i].message.data(), e + 32, 32);
         if (!secp256k1::SchnorrSignature::parse_strict(e + 64, batch[i].signature))
@@ -1656,10 +1661,11 @@ ufsecp_error_t ufsecp_musig2_start_sign_session(
     }
     auto qc = kagg.Q.to_compressed();
     std::memcpy(kagg.Q_x.data(), qc.data() + 1, 32);
-    for (uint32_t i = 0; i < nk && (38u + (i+1)*32u <= UFSECP_MUSIG2_KEYAGG_LEN); ++i) {
+    for (uint32_t i = 0; i < nk && (38u + static_cast<size_t>(i+1)*32u <= UFSECP_MUSIG2_KEYAGG_LEN); ++i) {
         Scalar s;
-        if (!scalar_parse_strict(keyagg + 38 + i * 32, s))
+        if (!scalar_parse_strict(keyagg + 38 + static_cast<size_t>(i) * 32, s)) {
             return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid key coefficient in keyagg");
+        }
         kagg.key_coefficients.push_back(s);
     }
     std::array<uint8_t, 32> msg_arr;
@@ -2133,14 +2139,16 @@ ufsecp_error_t ufsecp_schnorr_adaptor_sign(
         return UFSECP_ERR_NULL_ARG;
     ctx_clear_err(ctx);
     Scalar sk;
-    if (!scalar_parse_strict_nonzero(privkey, sk))
+    if (!scalar_parse_strict_nonzero(privkey, sk)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_KEY, "privkey is zero or >= n");
+    }
     std::array<uint8_t, 32> msg_arr, aux_arr;
     std::memcpy(msg_arr.data(), msg32, 32);
     std::memcpy(aux_arr.data(), aux_rand, 32);
     auto ap = point_from_compressed(adaptor_point33);
-    if (ap.is_infinity())
+    if (ap.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "invalid adaptor point");
+    }
     auto pre = secp256k1::schnorr_adaptor_sign(sk, msg_arr, ap, aux_arr);
     secp256k1::detail::secure_erase(&sk, sizeof(sk));
     auto rhat = pre.R_hat.to_compressed();
@@ -2159,8 +2167,9 @@ ufsecp_error_t ufsecp_schnorr_adaptor_verify(
     const uint8_t pubkey_x[32],
     const uint8_t msg32[32],
     const uint8_t adaptor_point33[33]) {
-    if (!ctx || !pre_sig || !pubkey_x || !msg32 || !adaptor_point33)
+    if (!ctx || !pre_sig || !pubkey_x || !msg32 || !adaptor_point33) {
         return UFSECP_ERR_NULL_ARG;
+    }
     ctx_clear_err(ctx);
     secp256k1::SchnorrAdaptorSig as;
     as.R_hat = point_from_compressed(pre_sig);
@@ -2182,10 +2191,12 @@ ufsecp_error_t ufsecp_schnorr_adaptor_verify(
     std::memcpy(pk_arr.data(), pubkey_x, 32);
     std::memcpy(msg_arr.data(), msg32, 32);
     auto ap = point_from_compressed(adaptor_point33);
-    if (ap.is_infinity())
+    if (ap.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "invalid adaptor point");
-    if (!secp256k1::schnorr_adaptor_verify(as, pk_arr, msg_arr, ap))
+    }
+    if (!secp256k1::schnorr_adaptor_verify(as, pk_arr, msg_arr, ap)) {
         return ctx_set_err(ctx, UFSECP_ERR_VERIFY_FAIL, "adaptor verify failed");
+    }
     return UFSECP_OK;
 }
 
@@ -2208,8 +2219,9 @@ ufsecp_error_t ufsecp_schnorr_adaptor_adapt(
     as.s_hat = shat;
     as.needs_negation = (pre_sig[65] != 0);
     Scalar secret;
-    if (!scalar_parse_strict_nonzero(adaptor_secret, secret))
+    if (!scalar_parse_strict_nonzero(adaptor_secret, secret)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "adaptor secret is zero or >= n");
+    }
     auto sig = secp256k1::schnorr_adaptor_adapt(as, secret);
     secp256k1::detail::secure_erase(&secret, sizeof(secret));
     auto bytes = sig.to_bytes();
@@ -2240,8 +2252,9 @@ ufsecp_error_t ufsecp_schnorr_adaptor_extract(
         return ctx_set_err(ctx, UFSECP_ERR_BAD_SIG, "invalid schnorr signature");
     }
     auto [secret, ok] = secp256k1::schnorr_adaptor_extract(as, sig);
-    if (!ok)
+    if (!ok) {
         return ctx_set_err(ctx, UFSECP_ERR_INTERNAL, "adaptor extract failed");
+    }
     scalar_to_bytes(secret, secret32_out);
     secp256k1::detail::secure_erase(&secret, sizeof(secret));
     return UFSECP_OK;
@@ -2253,17 +2266,20 @@ ufsecp_error_t ufsecp_ecdsa_adaptor_sign(
     const uint8_t msg32[32],
     const uint8_t adaptor_point33[33],
     uint8_t pre_sig_out[UFSECP_ECDSA_ADAPTOR_SIG_LEN]) {
-    if (!ctx || !privkey || !msg32 || !adaptor_point33 || !pre_sig_out)
+    if (!ctx || !privkey || !msg32 || !adaptor_point33 || !pre_sig_out) {
         return UFSECP_ERR_NULL_ARG;
+    }
     ctx_clear_err(ctx);
     Scalar sk;
-    if (!scalar_parse_strict_nonzero(privkey, sk))
+    if (!scalar_parse_strict_nonzero(privkey, sk)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_KEY, "privkey is zero or >= n");
+    }
     std::array<uint8_t, 32> msg_arr;
     std::memcpy(msg_arr.data(), msg32, 32);
     auto ap = point_from_compressed(adaptor_point33);
-    if (ap.is_infinity())
+    if (ap.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "invalid adaptor point");
+    }
     auto pre = secp256k1::ecdsa_adaptor_sign(sk, msg_arr, ap);
     secp256k1::detail::secure_erase(&sk, sizeof(sk));
     auto rhat = pre.R_hat.to_compressed();
@@ -2283,8 +2299,9 @@ ufsecp_error_t ufsecp_ecdsa_adaptor_verify(
     const uint8_t pubkey33[33],
     const uint8_t msg32[32],
     const uint8_t adaptor_point33[33]) {
-    if (!ctx || !pre_sig || !pubkey33 || !msg32 || !adaptor_point33)
+    if (!ctx || !pre_sig || !pubkey33 || !msg32 || !adaptor_point33) {
         return UFSECP_ERR_NULL_ARG;
+    }
     ctx_clear_err(ctx);
     secp256k1::ECDSAAdaptorSig as;
     as.R_hat = point_from_compressed(pre_sig);
@@ -2300,15 +2317,18 @@ ufsecp_error_t ufsecp_ecdsa_adaptor_verify(
         return ctx_set_err(ctx, UFSECP_ERR_BAD_SIG, "invalid adaptor sig r");
     }
     auto pk = point_from_compressed(pubkey33);
-    if (pk.is_infinity())
+    if (pk.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "invalid pubkey");
+    }
     std::array<uint8_t, 32> msg_arr;
     std::memcpy(msg_arr.data(), msg32, 32);
     auto ap = point_from_compressed(adaptor_point33);
-    if (ap.is_infinity())
+    if (ap.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "invalid adaptor point");
-    if (!secp256k1::ecdsa_adaptor_verify(as, pk, msg_arr, ap))
+    }
+    if (!secp256k1::ecdsa_adaptor_verify(as, pk, msg_arr, ap)) {
         return ctx_set_err(ctx, UFSECP_ERR_VERIFY_FAIL, "ECDSA adaptor verify failed");
+    }
     return UFSECP_OK;
 }
 
@@ -2333,8 +2353,9 @@ ufsecp_error_t ufsecp_ecdsa_adaptor_adapt(
         return ctx_set_err(ctx, UFSECP_ERR_BAD_SIG, "invalid adaptor sig r");
     }
     Scalar secret;
-    if (!scalar_parse_strict_nonzero(adaptor_secret, secret))
+    if (!scalar_parse_strict_nonzero(adaptor_secret, secret)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "adaptor secret is zero or >= n");
+    }
     auto sig = secp256k1::ecdsa_adaptor_adapt(as, secret);
     secp256k1::detail::secure_erase(&secret, sizeof(secret));
     auto compact = sig.to_compact();
@@ -2365,11 +2386,13 @@ ufsecp_error_t ufsecp_ecdsa_adaptor_extract(
     std::array<uint8_t, 64> compact;
     std::memcpy(compact.data(), sig64, 64);
     secp256k1::ECDSASignature ecdsasig;
-    if (!secp256k1::ECDSASignature::parse_compact_strict(compact, ecdsasig))
+    if (!secp256k1::ECDSASignature::parse_compact_strict(compact, ecdsasig)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_SIG, "invalid ECDSA sig");
+    }
     auto [secret, ok] = secp256k1::ecdsa_adaptor_extract(as, ecdsasig);
-    if (!ok)
+    if (!ok) {
         return ctx_set_err(ctx, UFSECP_ERR_INTERNAL, "ECDSA adaptor extract failed");
+    }
     scalar_to_bytes(secret, secret32_out);
     secp256k1::detail::secure_erase(&secret, sizeof(secret));
     return UFSECP_OK;
@@ -2386,10 +2409,12 @@ ufsecp_error_t ufsecp_pedersen_commit(ufsecp_ctx* ctx,
     if (!ctx || !value || !blinding || !commitment33_out) return UFSECP_ERR_NULL_ARG;
     ctx_clear_err(ctx);
     Scalar v, b;
-    if (!scalar_parse_strict(value, v))
+    if (!scalar_parse_strict(value, v)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "value >= n");
-    if (!scalar_parse_strict(blinding, b))
+    }
+    if (!scalar_parse_strict(blinding, b)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "blinding >= n");
+    }
     auto c = secp256k1::pedersen_commit(v, b);
     auto comp = c.point.to_compressed();
     std::memcpy(commitment33_out, comp.data(), 33);
@@ -2403,10 +2428,12 @@ ufsecp_error_t ufsecp_pedersen_verify(ufsecp_ctx* ctx,
     if (!ctx || !commitment33 || !value || !blinding) return UFSECP_ERR_NULL_ARG;
     ctx_clear_err(ctx);
     Scalar v, b;
-    if (!scalar_parse_strict(value, v))
+    if (!scalar_parse_strict(value, v)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "value >= n");
-    if (!scalar_parse_strict(blinding, b))
+    }
+    if (!scalar_parse_strict(blinding, b)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "blinding >= n");
+    }
     auto commit_pt = point_from_compressed(commitment33);
     if (commit_pt.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid commitment point");
@@ -2437,8 +2464,9 @@ ufsecp_error_t ufsecp_pedersen_verify_sum(ufsecp_ctx* ctx,
         }
         ncs[i] = secp256k1::PedersenCommitment{p};
     }
-    if (!secp256k1::pedersen_verify_sum(pcs.data(), n_pos, ncs.data(), n_neg))
+    if (!secp256k1::pedersen_verify_sum(pcs.data(), n_pos, ncs.data(), n_neg)) {
         return ctx_set_err(ctx, UFSECP_ERR_VERIFY_FAIL, "Pedersen sum verify failed");
+    }
     return UFSECP_OK;
 }
 
@@ -2471,16 +2499,20 @@ ufsecp_error_t ufsecp_pedersen_switch_commit(ufsecp_ctx* ctx,
                                              const uint8_t blinding[32],
                                              const uint8_t switch_blind[32],
                                              uint8_t commitment33_out[33]) {
-    if (!ctx || !value || !blinding || !switch_blind || !commitment33_out)
+    if (!ctx || !value || !blinding || !switch_blind || !commitment33_out) {
         return UFSECP_ERR_NULL_ARG;
+    }
     ctx_clear_err(ctx);
     Scalar v, b, sb;
-    if (!scalar_parse_strict(value, v))
+    if (!scalar_parse_strict(value, v)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "value >= n");
-    if (!scalar_parse_strict(blinding, b))
+    }
+    if (!scalar_parse_strict(blinding, b)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "blinding >= n");
-    if (!scalar_parse_strict(switch_blind, sb))
+    }
+    if (!scalar_parse_strict(switch_blind, sb)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "switch_blind >= n");
+    }
     auto c = secp256k1::pedersen_switch_commit(v, b, sb);
     auto comp = c.point.to_compressed();
     std::memcpy(commitment33_out, comp.data(), 33);
@@ -2498,15 +2530,18 @@ ufsecp_error_t ufsecp_zk_knowledge_prove(
     const uint8_t msg32[32],
     const uint8_t aux_rand[32],
     uint8_t proof_out[UFSECP_ZK_KNOWLEDGE_PROOF_LEN]) {
-    if (!ctx || !secret || !pubkey33 || !msg32 || !aux_rand || !proof_out)
+    if (!ctx || !secret || !pubkey33 || !msg32 || !aux_rand || !proof_out) {
         return UFSECP_ERR_NULL_ARG;
+    }
     ctx_clear_err(ctx);
     Scalar s;
-    if (!scalar_parse_strict_nonzero(secret, s))
+    if (!scalar_parse_strict_nonzero(secret, s)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_KEY, "secret is zero or >= n");
+    }
     auto pk = point_from_compressed(pubkey33);
-    if (pk.is_infinity())
+    if (pk.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "invalid pubkey");
+    }
     std::array<uint8_t, 32> msg_arr, aux_arr;
     std::memcpy(msg_arr.data(), msg32, 32);
     std::memcpy(aux_arr.data(), aux_rand, 32);
@@ -2525,15 +2560,18 @@ ufsecp_error_t ufsecp_zk_knowledge_verify(
     if (!ctx || !proof || !pubkey33 || !msg32) return UFSECP_ERR_NULL_ARG;
     ctx_clear_err(ctx);
     auto pk = point_from_compressed(pubkey33);
-    if (pk.is_infinity())
+    if (pk.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "invalid pubkey");
+    }
     secp256k1::zk::KnowledgeProof kp;
-    if (!secp256k1::zk::KnowledgeProof::deserialize(proof, kp))
+    if (!secp256k1::zk::KnowledgeProof::deserialize(proof, kp)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid knowledge proof");
+    }
     std::array<uint8_t, 32> msg_arr;
     std::memcpy(msg_arr.data(), msg32, 32);
-    if (!secp256k1::zk::knowledge_verify(kp, pk, msg_arr))
+    if (!secp256k1::zk::knowledge_verify(kp, pk, msg_arr)) {
         return ctx_set_err(ctx, UFSECP_ERR_VERIFY_FAIL, "knowledge proof failed");
+    }
     return UFSECP_OK;
 }
 
@@ -2544,12 +2582,14 @@ ufsecp_error_t ufsecp_zk_dleq_prove(
     const uint8_t P33[33], const uint8_t Q33[33],
     const uint8_t aux_rand[32],
     uint8_t proof_out[UFSECP_ZK_DLEQ_PROOF_LEN]) {
-    if (!ctx || !secret || !G33 || !H33 || !P33 || !Q33 || !aux_rand || !proof_out)
+    if (!ctx || !secret || !G33 || !H33 || !P33 || !Q33 || !aux_rand || !proof_out) {
         return UFSECP_ERR_NULL_ARG;
+    }
     ctx_clear_err(ctx);
     Scalar s;
-    if (!scalar_parse_strict_nonzero(secret, s))
+    if (!scalar_parse_strict_nonzero(secret, s)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_KEY, "secret is zero or >= n");
+    }
     auto G = point_from_compressed(G33);
     auto H = point_from_compressed(H33);
     auto P = point_from_compressed(P33);
@@ -2581,10 +2621,12 @@ ufsecp_error_t ufsecp_zk_dleq_verify(
         return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "invalid DLEQ point");
     }
     secp256k1::zk::DLEQProof dp;
-    if (!secp256k1::zk::DLEQProof::deserialize(proof, dp))
+    if (!secp256k1::zk::DLEQProof::deserialize(proof, dp)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid DLEQ proof");
-    if (!secp256k1::zk::dleq_verify(dp, G, H, P, Q))
+    }
+    if (!secp256k1::zk::dleq_verify(dp, G, H, P, Q)) {
         return ctx_set_err(ctx, UFSECP_ERR_VERIFY_FAIL, "DLEQ proof failed");
+    }
     return UFSECP_OK;
 }
 
@@ -2595,8 +2637,9 @@ ufsecp_error_t ufsecp_zk_range_prove(
     const uint8_t commitment33[33],
     const uint8_t aux_rand[32],
     uint8_t* proof_out, size_t* proof_len) {
-    if (!ctx || !blinding || !commitment33 || !aux_rand || !proof_out || !proof_len)
+    if (!ctx || !blinding || !commitment33 || !aux_rand || !proof_out || !proof_len) {
         return UFSECP_ERR_NULL_ARG;
+    }
     ctx_clear_err(ctx);
     Scalar b;
     if (!scalar_parse_strict(blinding, b)) {
@@ -2611,9 +2654,10 @@ ufsecp_error_t ufsecp_zk_range_prove(
     std::memcpy(aux_arr.data(), aux_rand, 32);
     auto rp = secp256k1::zk::range_prove(value, b, commit, aux_arr);
     /* Serialize range proof: A(33)+S(33)+T1(33)+T2(33)+tau_x(32)+mu(32)+t_hat(32)+L[6]*33+R[6]*33+a(32)+b(32) */
-    size_t needed = 33*4 + 32*3 + 6*33 + 6*33 + 32*2;
-    if (*proof_len < needed)
+    const size_t needed = 33*4 + 32*3 + 6*33 + 6*33 + 32*2;
+    if (*proof_len < needed) {
         return ctx_set_err(ctx, UFSECP_ERR_BUF_TOO_SMALL, "range proof buffer too small");
+    }
     size_t off = 0;
     auto write_point = [&](const Point& p) {
         auto c = p.to_compressed();
@@ -2641,9 +2685,10 @@ ufsecp_error_t ufsecp_zk_range_verify(
     if (!ctx || !commitment33 || !proof) return UFSECP_ERR_NULL_ARG;
     ctx_clear_err(ctx);
     /* Deserialize range proof */
-    size_t expected = 33*4 + 32*3 + 6*33 + 6*33 + 32*2;
-    if (proof_len < expected)
+    const size_t expected = 33*4 + 32*3 + 6*33 + 6*33 + 32*2;
+    if (proof_len < expected) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "range proof too short");
+    }
     secp256k1::zk::RangeProof rp;
     size_t off = 0;
     bool point_ok = true;
@@ -2679,8 +2724,9 @@ ufsecp_error_t ufsecp_zk_range_verify(
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "invalid commitment point");
     }
     auto commit = secp256k1::PedersenCommitment{commit_pt};
-    if (!secp256k1::zk::range_verify(commit, rp))
+    if (!secp256k1::zk::range_verify(commit, rp)) {
         return ctx_set_err(ctx, UFSECP_ERR_VERIFY_FAIL, "range proof failed");
+    }
     return UFSECP_OK;
 }
 
@@ -2699,17 +2745,20 @@ ufsecp_error_t ufsecp_coin_address(ufsecp_ctx* ctx,
     if (!ctx || !pubkey33 || !addr_out || !addr_len) return UFSECP_ERR_NULL_ARG;
     ctx_clear_err(ctx);
     auto coin = find_coin(coin_type);
-    if (!coin)
+    if (!coin) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "unknown coin type");
+    }
     auto pk = point_from_compressed(pubkey33);
     if (pk.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "invalid pubkey");
     }
     auto addr = secp256k1::coins::coin_address(pk, *coin, testnet != 0);
-    if (addr.empty())
+    if (addr.empty()) {
         return ctx_set_err(ctx, UFSECP_ERR_INTERNAL, "address generation failed");
-    if (*addr_len < addr.size() + 1)
+    }
+    if (*addr_len < addr.size() + 1) {
         return ctx_set_err(ctx, UFSECP_ERR_BUF_TOO_SMALL, "address buffer too small");
+    }
     std::memcpy(addr_out, addr.c_str(), addr.size() + 1);
     *addr_len = addr.size();
     return UFSECP_OK;
@@ -2726,17 +2775,20 @@ ufsecp_error_t ufsecp_coin_derive_from_seed(
     if (!ctx || !seed) return UFSECP_ERR_NULL_ARG;
     ctx_clear_err(ctx);
     auto coin = find_coin(coin_type);
-    if (!coin)
+    if (!coin) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "unknown coin type");
+    }
     /* BIP-32 master */
     auto [master, m_ok] = secp256k1::bip32_master_key(seed, seed_len);
-    if (!m_ok)
+    if (!m_ok) {
         return ctx_set_err(ctx, UFSECP_ERR_INTERNAL, "BIP-32 master key failed");
+    }
     /* Derive coin key */
     auto [key, d_ok] = secp256k1::coins::coin_derive_key(
         master, *coin, account, change != 0, index);
-    if (!d_ok)
+    if (!d_ok) {
         return ctx_set_err(ctx, UFSECP_ERR_INTERNAL, "coin key derivation failed");
+    }
     if (privkey32_out) {
         auto sk = key.private_key();
         scalar_to_bytes(sk, privkey32_out);
@@ -2747,12 +2799,14 @@ ufsecp_error_t ufsecp_coin_derive_from_seed(
     secp256k1::detail::secure_erase(master.chain_code.data(), master.chain_code.size());
     secp256k1::detail::secure_erase(key.key.data(), key.key.size());
     secp256k1::detail::secure_erase(key.chain_code.data(), key.chain_code.size());
-    if (pubkey33_out)
+    if (pubkey33_out) {
         point_to_compressed(pk, pubkey33_out);
+    }
     if (addr_out && addr_len) {
         auto addr = secp256k1::coins::coin_address(pk, *coin, testnet != 0);
-        if (*addr_len < addr.size() + 1)
+        if (*addr_len < addr.size() + 1) {
             return ctx_set_err(ctx, UFSECP_ERR_BUF_TOO_SMALL, "address buffer too small");
+        }
         std::memcpy(addr_out, addr.c_str(), addr.size() + 1);
         *addr_len = addr.size();
     }
@@ -2766,11 +2820,13 @@ ufsecp_error_t ufsecp_coin_wif_encode(ufsecp_ctx* ctx,
     if (!ctx || !privkey || !wif_out || !wif_len) return UFSECP_ERR_NULL_ARG;
     ctx_clear_err(ctx);
     auto coin = find_coin(coin_type);
-    if (!coin)
+    if (!coin) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_INPUT, "unknown coin type");
+    }
     Scalar sk;
-    if (!scalar_parse_strict_nonzero(privkey, sk))
+    if (!scalar_parse_strict_nonzero(privkey, sk)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_KEY, "privkey is zero or >= n");
+    }
     auto wif = secp256k1::coins::coin_wif_encode(sk, *coin, true, testnet != 0);
     secp256k1::detail::secure_erase(&sk, sizeof(sk));
     if (wif.empty())
@@ -2789,13 +2845,15 @@ ufsecp_error_t ufsecp_btc_message_sign(ufsecp_ctx* ctx,
     if (!ctx || !msg || !privkey || !base64_out || !base64_len) return UFSECP_ERR_NULL_ARG;
     ctx_clear_err(ctx);
     Scalar sk;
-    if (!scalar_parse_strict_nonzero(privkey, sk))
+    if (!scalar_parse_strict_nonzero(privkey, sk)) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_KEY, "privkey is zero or >= n");
+    }
     auto rsig = secp256k1::coins::bitcoin_sign_message(msg, msg_len, sk);
     secp256k1::detail::secure_erase(&sk, sizeof(sk));
     auto b64 = secp256k1::coins::bitcoin_sig_to_base64(rsig);
-    if (*base64_len < b64.size() + 1)
+    if (*base64_len < b64.size() + 1) {
         return ctx_set_err(ctx, UFSECP_ERR_BUF_TOO_SMALL, "base64 buffer too small");
+    }
     std::memcpy(base64_out, b64.c_str(), b64.size() + 1);
     *base64_len = b64.size();
     return UFSECP_OK;
@@ -2808,13 +2866,16 @@ ufsecp_error_t ufsecp_btc_message_verify(ufsecp_ctx* ctx,
     if (!ctx || !msg || !pubkey33 || !base64_sig) return UFSECP_ERR_NULL_ARG;
     ctx_clear_err(ctx);
     auto pk = point_from_compressed(pubkey33);
-    if (pk.is_infinity())
+    if (pk.is_infinity()) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_PUBKEY, "invalid pubkey");
+    }
     auto dec = secp256k1::coins::bitcoin_sig_from_base64(std::string(base64_sig));
-    if (!dec.valid)
+    if (!dec.valid) {
         return ctx_set_err(ctx, UFSECP_ERR_BAD_SIG, "invalid base64 signature");
-    if (!secp256k1::coins::bitcoin_verify_message(msg, msg_len, pk, dec.sig))
+    }
+    if (!secp256k1::coins::bitcoin_verify_message(msg, msg_len, pk, dec.sig)) {
         return ctx_set_err(ctx, UFSECP_ERR_VERIFY_FAIL, "BTC message verify failed");
+    }
     return UFSECP_OK;
 }
 


### PR DESCRIPTION
Addresses all open GitHub code-scanning alerts remaining after PR #156.

## Files changed

### `audit/test_adversarial_protocol.cpp` (21 alerts)
- **cert-err34-c** (L40): Replace `std::sscanf` with `std::strtoul` in `hex_to_bytes` for safe string-to-number conversion
- **misc-const-correctness** (14x): Add `const` to `rc1`, `rc2`, `rc`, `arc`, `vrc`, `match` variables that are never reassigned
- **bugprone-implicit-widening** (2x, L623/L707): Add `static_cast<size_t>` before `uint32_t * constant` multiplications
- **duplicateAssignExpression** (L780): Separate `commits_len`/`shares_len` into distinct declarations
- **cppcoreguidelines-init-variables** (L2133/L2270/L2438): Initialise `parity`, `compressed_out`, `network_out`, `v` to 0
- **argumentSize/array-arg-size-mismatch** (L2403/L2406): Expand `priv[32]` to `priv[33]` to match `ufsecp_coin_address` `pubkey33[33]` expectation

### `audit/test_ecies_regression.cpp` (8 alerts)
- **misc-const-correctness** (7x): Add `const` to `pt_len`, `err`, `prefix`, `sz`
- **cert-err33-c** (L136): Add `(void)` cast to `std::snprintf` whose return value was unused

### `include/ufsecp/ufsecp_impl.cpp` (61+ alerts)
- **readability-braces-around-statements** (59x): Add `{ }` around all single-statement `if`-bodies in schnorr/ecdsa adaptor, ZK proof, Pedersen commitment, and multi-coin wallet sections
- **misc-const-correctness** (2x): Add `const` to `needed` and `expected` size variables
- **bugprone-implicit-widening** (L1661): Cast `uint32_t` loop index with `static_cast<size_t>` before multiplication

No functional behaviour changes. All fixes are purely code-quality and static-analysis compliance.

Addresses remaining alerts after PR #156 (round 2).