### PR TITLE
fix: restore valid BIP-39 audit vector and clean cashaddr warning

### DIFF
--- a/audit/test_ffi_round_trip.cpp
+++ b/audit/test_ffi_round_trip.cpp
@@ -1050,9 +1050,13 @@ static void test_bip39_round_trip() {
     // Validate
     CHECK_OK(ufsecp_bip39_validate(ctx, mnemonic), "bip39_validate");
 
-    // Invalid mnemonic
-    CHECK(ufsecp_bip39_validate(ctx, "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon") == UFSECP_OK,
+    // Known valid 12-word mnemonic (BIP-39 test vector)
+    CHECK(ufsecp_bip39_validate(ctx, "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about") == UFSECP_OK,
           "bip39_validate accepts valid 12-word mnemonic");
+
+    // Invalid checksum variant
+    CHECK(ufsecp_bip39_validate(ctx, "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon") == UFSECP_ERR_BAD_INPUT,
+          "bip39_validate rejects invalid checksum mnemonic");
 
     // To seed
     uint8_t seed[64];

--- a/cpu/src/address.cpp
+++ b/cpu/src/address.cpp
@@ -513,7 +513,10 @@ static std::uint64_t cashaddr_polymod(const std::vector<std::uint8_t>& v) {
 static std::vector<std::uint8_t> cashaddr_prefix_expand(const std::string& prefix) {
     std::vector<std::uint8_t> ret;
     ret.reserve(prefix.size() + 1);
-    for (const char c : prefix) ret.push_back(static_cast<std::uint8_t>(c & 0x1f));    ret.push_back(0);
+    for (const char c : prefix) {
+        ret.push_back(static_cast<std::uint8_t>(c & 0x1f));
+    }
+    ret.push_back(0);
     return ret;
 }
 

--- a/cpu/src/multiscalar.cpp
+++ b/cpu/src/multiscalar.cpp
@@ -133,7 +133,11 @@ Point multi_scalar_mul(const Scalar* scalars,
         // Build tables using Point-level operations (handles all edge cases)
         std::vector<Point> base_pts(n);
         for (std::size_t i = 0; i < n; ++i) {
-            base_pts[i] = glv_info[i].neg1 ? points[i].negate() : points[i];
+            if (glv_info[i].neg1) {
+                base_pts[i] = points[i].negate();
+            } else {
+                base_pts[i] = points[i];
+            }
         }
 
         // Build odd-multiple tables: [1Q, 3Q, 5Q, ..., (2T-1)Q]


### PR DESCRIPTION
## Summary
- restore the FFI audit to use a valid 12-word BIP-39 test vector
- add an explicit invalid-checksum assertion for the all-`abandon` mnemonic
- fix the misleading-indentation warning in cashaddr prefix expansion
- rewrite the multiscalar point selection branch to avoid a GCC `-Wstringop-overflow` false positive in `-Werror` builds

## Why
The previous change made `unified_audit` require an invalid mnemonic to validate successfully, which broke CI and coverage across platforms. The same push also surfaced strict-warning failures in the Security Audit `-Werror` build.

## Verification
- built `unified_audit_runner`
- ran `ctest --test-dir build-ci -R ^unified_audit --output-on-failure` successfully in a clean clone
- confirmed the GCC warning in `cpu/src/address.cpp` is gone after the formatting fix
- confirmed the GCC `multiscalar.cpp` warning no longer appears when rebuilding under `-Werror`
