### PR TITLE
fix: clear remaining low-level code scanning alerts

### DIFF
--- a/cpu/src/ct_sign.cpp
+++ b/cpu/src/ct_sign.cpp
@@ -337,9 +337,9 @@ RecoverableSignature ecdsa_sign_recoverable(
     if (s.is_zero()) return {{Scalar::zero(), Scalar::zero()}, 0};
 
     // CT low-S normalization (branchless).
-    ECDSASignature pre_sig{r, s};
+    const ECDSASignature pre_sig{r, s};
     bool const was_high = !pre_sig.is_low_s();
-    ECDSASignature sig = ct::ct_normalize_low_s(pre_sig);
+    const ECDSASignature sig = ct::ct_normalize_low_s(pre_sig);
     // Negating s flips the R.y parity bit in the recovery ID.
     if (was_high) recid ^= 1;
 

--- a/cpu/src/message_signing.cpp
+++ b/cpu/src/message_signing.cpp
@@ -156,15 +156,15 @@ static bool base64_decode(const std::string& b64, std::uint8_t* out, std::size_t
     for (std::size_t i = 0; i < b64.size(); i += 4) {
         const int a = base64_char_value(b64[i]);
         const int b = base64_char_value(b64[i + 1]);
-        int c = (b64[i + 2] == '=') ? 0 : base64_char_value(b64[i + 2]);
-        int d = (b64[i + 3] == '=') ? 0 : base64_char_value(b64[i + 3]);
+        const int c = (b64[i + 2] == '=') ? 0 : base64_char_value(b64[i + 2]);
+        const int d = (b64[i + 3] == '=') ? 0 : base64_char_value(b64[i + 3]);
 
         if (a < 0 || b < 0 || c < 0 || d < 0) return false;
 
-        std::uint32_t triple = (static_cast<std::uint32_t>(a) << 18) |
-                               (static_cast<std::uint32_t>(b) << 12) |
-                               (static_cast<std::uint32_t>(c) << 6) |
-                               static_cast<std::uint32_t>(d);
+        const std::uint32_t triple = (static_cast<std::uint32_t>(a) << 18) |
+                                     (static_cast<std::uint32_t>(b) << 12) |
+                                     (static_cast<std::uint32_t>(c) << 6) |
+                                     static_cast<std::uint32_t>(d);
 
         if (out_idx < expected_len) out[out_idx++] = static_cast<std::uint8_t>((triple >> 16) & 0xFF);
         if (out_idx < expected_len) out[out_idx++] = static_cast<std::uint8_t>((triple >> 8) & 0xFF);
@@ -195,10 +195,10 @@ BitcoinSigDecodeResult bitcoin_sig_from_base64(const std::string& base64_str) {
     std::uint8_t buf[65];
     if (!base64_decode(base64_str, buf, 65)) return result;
 
-    std::uint8_t header = buf[0];
+    const std::uint8_t header = buf[0];
     if (header < 27 || header > 34) return result;
 
-    int flag = header - 27;
+    const int flag = header - 27;
     result.recid = flag & 3;
     result.compressed = (flag & 4) != 0;
 

--- a/cpu/tests/test_bip39.cpp
+++ b/cpu/tests/test_bip39.cpp
@@ -312,9 +312,9 @@ static void test_random_generation() {
     CHECK(bip39_validate(m24), "random 24-word validates");
 
     // Invalid sizes rejected
-    auto [bad1, ok_bad1] = bip39_generate(15);
+    const auto ok_bad1 = bip39_generate(15).second;
     CHECK(!ok_bad1, "15-byte entropy rejected");
-    auto [bad2, ok_bad2] = bip39_generate(33);
+    const auto ok_bad2 = bip39_generate(33).second;
     CHECK(!ok_bad2, "33-byte entropy rejected");
 }
 

--- a/cpu/tests/test_ethereum.cpp
+++ b/cpu/tests/test_ethereum.cpp
@@ -269,13 +269,13 @@ static void test_ecrecover() {
     // ecrecover with invalid r=0 should fail
     TEST("ecrecover invalid r=0");
     const std::array<uint8_t, 32> zero{};
-    auto [_, ok4] = ecrecover(hash, zero, sig.s, sig.v);
+    const auto ok4 = ecrecover(hash, zero, sig.s, sig.v).second;
     ASSERT_TRUE(!ok4, "ecrecover with r=0 should fail");
     PASS();
 
     // ecrecover with invalid s=0 should fail
     TEST("ecrecover invalid s=0");
-    auto [_2, ok5] = ecrecover(hash, sig.r, zero, sig.v);
+    const auto ok5 = ecrecover(hash, sig.r, zero, sig.v).second;
     ASSERT_TRUE(!ok5, "ecrecover with s=0 should fail");
     PASS();
 }

--- a/cpu/tests/test_wallet.cpp
+++ b/cpu/tests/test_wallet.cpp
@@ -103,7 +103,7 @@ static void test_from_private_key_valid() {
 static void test_from_private_key_zero() {
     TEST("from_private_key: zero key rejected");
     uint8_t priv[32] = {};
-    auto [key, ok] = from_private_key(priv);
+    const auto ok = from_private_key(priv).second;
     ASSERT_TRUE(!ok, "should fail for zero");
     PASS();
 }


### PR DESCRIPTION
## Summary
- apply const-correctness cleanups in `ct_sign.cpp` and `message_signing.cpp`
- remove unused local variables in `test_bip39.cpp`, `test_wallet.cpp`, and `test_ethereum.cpp`

## Why
These changes close the remaining low-severity code scanning alerts without changing behavior.

## Verification
- built `test_bip39_standalone`, `test_wallet_standalone`, `test_ethereum_standalone`, and `unified_audit_runner`
- ran `ctest --test-dir build-fix -R "^(bip39|wallet|ethereum|unified_audit)$" --output-on-failure`
