### PR TITLE
fix: use scalar_mul_glv in generator_mul_batch Metal kernel

### DIFF
--- a/metal/shaders/secp256k1_kernels.metal
+++ b/metal/shaders/secp256k1_kernels.metal
@@ -160,7 +160,7 @@ kernel void generator_mul_batch(
     AffinePoint gen = generator_affine();
     Scalar256 k = scalars[tid];
 
-    JacobianPoint jac = scalar_mul(gen, k);
+    JacobianPoint jac = scalar_mul_glv(gen, k);
     results[tid] = jacobian_to_affine(jac);
 }
 


### PR DESCRIPTION
## Summary

- `scalar_mul_batch` already uses `scalar_mul_glv` (GLV endomorphism) but `generator_mul_batch` still called the non-GLV `scalar_mul` with a basic 4-bit window
- One-line change to bring `generator_mul_batch` in line with `scalar_mul_batch`, roughly halving the doublings per scalar multiplication

## Benchmark

Measured on Apple M1 Pro (BIP-352 scanning pipeline, 10K points, 11 passes, median):

| Config | ns/op |
|--------|-------|
| Metal (GLV on k*P only) | 9,400 |
| **Metal (GLV on both k*P and k*G)** | **8,900** |

## Test plan

- [x] Metal audit runner: 27/27 PASS, no regressions
- [x] BIP-352 benchmark validation prefix matches (`0xb63b4601066a6971`)