### PR TITLE
fix(audit): raise BSPA-8 timing guardrail from 3x to 5x for noisy CI …

### DIFF
--- a/audit/test_exploit_blind_spa_cmov_leak.cpp
+++ b/audit/test_exploit_blind_spa_cmov_leak.cpp
@@ -194,8 +194,11 @@ int test_exploit_blind_spa_cmov_leak_run() {
 
         AUDIT_LOG("  [BSPA-8] HW1=%.2fus HW255=%.2fus mixed=%.2fus r1=%.3f r2=%.3f\n",
                   hw1_us, hw255_us, mixed_us, ratio_1, ratio_2);
-        CHECK(ratio_1 < 3.0 && ratio_2 < 3.0,
-              "BSPA-8: HW-extreme vs mixed timing ratio < 3x");
+        // CI guard-rail only — real CT assurance is in ct_sidechannel.
+        // Raised from 3x to 5x: shared CI runners (macOS-arm64 especially)
+        // have noisy scheduling that causes sporadic >3x ratios.
+        CHECK(ratio_1 < 5.0 && ratio_2 < 5.0,
+              "BSPA-8: HW-extreme vs mixed timing ratio < 5x");
     }
 
     // --- BSPA-9: Schnorr sign determinism ---


### PR DESCRIPTION
…runners

macOS-arm64 shared runners have scheduling noise that sporadically causes
>3x timing ratios between HW-extreme and mixed keys. This is a CI
guardrail only — real CT assurance is provided by ct_sidechannel tests. Raised threshold to 5x to eliminate false positives.

## Description

<!-- Brief summary of changes -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Performance improvement
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] CI/Build infrastructure

## Changes Made

<!-- List key changes -->

-

## Testing

- [ ] All existing tests pass (`ctest --test-dir build --output-on-failure`)
- [ ] New tests added (if applicable)
- [ ] Benchmark results attached (if performance-related)

## Hot Path Checklist (if applicable)

- [ ] Zero heap allocations in hot path
- [ ] No strings/iostreams/exceptions in hot path
- [ ] Explicit in/out/scratch buffers
- [ ] No `%` or `/` where Montgomery/Barrett is available

## Additional Notes

<!-- Any other context about the PR -->
