### PR TITLE
fix(cuda): resolve undefined reference for batch kernel

### DIFF
--- a/src/cuda/include/secp256k1.cuh
+++ b/src/cuda/include/secp256k1.cuh
@@ -2709,6 +2709,9 @@ __global__ void point_dbl_kernel(const JacobianPoint* a, JacobianPoint* r, int c
 __global__ void scalar_mul_batch_kernel(const JacobianPoint* points, const Scalar* scalars, 
                                          JacobianPoint* results, int count);
 
+// Extern declaration for batch kernel to allow access from gpu_backend_cuda translation unit                                         
+__global__ void ct_generator_mul_batch_kernel(const Scalar* scalars, JacobianPoint* results, int count);
+
 // Generator multiplication kernel (optimized for G * k)
 __global__ void generator_mul_batch_kernel(const Scalar* scalars, JacobianPoint* results, int count);
 


### PR DESCRIPTION
## Description

Fixed a compilation error in gpu_backend_cuda.cu where the batch processing kernel (ct_generator_mul_batch_kernel) were causing "undefined identifier" errors.

```
/home/furkanadmin/Repo/UltrafastSecp256k1/src/gpu/src/gpu_backend_cuda.cu(453): error: identifier "ct_generator_mul_batch_kernel" is undefined

```

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Performance improvement
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] CI/Build infrastructure

## Changes Made

- Added extern __global__ declarations for CUDA batch kernels to make them visible to the GPU backend host operations.



## Testing

- [ ] All existing tests pass (`ctest --test-dir build --output-on-failure`)
- [ ] New tests added (if applicable)
- [ ] Benchmark results attached (if performance-related)

## Hot Path Checklist (if applicable)

- [ ] Zero heap allocations in hot path
- [ ] No strings/iostreams/exceptions in hot path
- [ ] Explicit in/out/scratch buffers
- [ ] No `%` or `/` where Montgomery/Barrett is available

## Additional Notes
The build now completes successfully, and basic mathematical primitives pass the audit. However, several signature and protocol tests are failing.

  GPU AUDIT VERDICT: AUDIT-BLOCKED
  TOTAL: 37/45 modules passed  --  8 FAILED  (94.4 s)
  GPU: NVIDIA GeForce RTX 3060 Laptop GPU (8.6) | Linux x86-64

This PR only fixes the build error. The test failures I encountered seem to be existing issues in the project and are not related to my changes.