### PR TITLE
fix(bridge): prefix ufsecp_libbitcoin.h include with ufsecp/

### DIFF
--- a/compat/libbitcoin_bridge/include/ufsecp_libbitcoin.h
+++ b/compat/libbitcoin_bridge/include/ufsecp_libbitcoin.h
@@ -59,7 +59,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include "ufsecp_error.h" /* ufsecp_error_t, UFSECP_OK, UFSECP_ERR_* */
+#include "ufsecp/ufsecp_error.h" /* ufsecp_error_t, UFSECP_OK, UFSECP_ERR_* */
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
## Problem

`compat/libbitcoin_bridge/include/ufsecp_libbitcoin.h` does:

```c
#include "ufsecp_error.h"
```

This only resolves when `include/ufsecp/` is itself on the include path as a
separate base. That's inconsistent with the rest of the tree — e.g. the shim's
`secp256k1.h` uses `#include "secp256k1/ecdsa.hpp"` (prefixed with its subdir) —
and it breaks any consumer that puts a single `include/` root on the path with
`secp256k1/` and `ufsecp/` as subdirs (e.g. a NuGet package shipping headers
under `include/`).

## Fix

Use the directory-prefixed form:

```c
#include "ufsecp/ufsecp_error.h"
```

so a single `include/` root resolves it, consistent with the `secp256k1/`-prefixed
engine headers. One-line, header-only change.