### PR TITLE
Release v4.3.0 re-cut #3: shim off-curve fail-closed fix

### DIFF
--- a/audit/test_regression_p2_ct_shim_fixes.cpp
+++ b/audit/test_regression_p2_ct_shim_fixes.cpp
@@ -282,6 +282,26 @@ static void test_shim_fail_closed_outputs() {
     for (unsigned char b : bad_pk.data) pubkey_zero = pubkey_zero && (b == 0);
     CHECK(pubkey_zero, "SHIM-FC: pubkey_negate failure clears in-place pubkey");
 
+    // The pubkey MANIPULATION paths share one curve-checked loader
+    // (pubkey_data_to_point_checked) so they are uniformly FAIL-CLOSED on an
+    // off-curve opaque pubkey — not only negate/serialize. The hot verify paths use
+    // the unchecked loader (PERF-002). Guard tweak_add/tweak_mul here too.
+    {
+        secp256k1_pubkey oc;
+        CHECK(secp256k1_ec_pubkey_create(sctx(), &oc, kSk1) == 1,
+              "SHIM-FC: create pubkey for off-curve tweak test");
+        oc.data[40] ^= 0xFF;  // corrupt a y byte -> off-curve
+        uint8_t small_tweak[32];
+        std::memset(small_tweak, 0, sizeof(small_tweak));
+        small_tweak[31] = 2;
+        secp256k1_pubkey t1 = oc;
+        CHECK(secp256k1_ec_pubkey_tweak_add(sctx(), &t1, small_tweak) == 0,
+              "SHIM-FC: pubkey_tweak_add rejects off-curve input");
+        secp256k1_pubkey t2 = oc;
+        CHECK(secp256k1_ec_pubkey_tweak_mul(sctx(), &t2, small_tweak) == 0,
+              "SHIM-FC: pubkey_tweak_mul rejects off-curve input");
+    }
+
     secp256k1_xonly_pubkey bad_xonly;
     std::memset(&bad_xonly, 0, sizeof(bad_xonly));
     unsigned char xout[32];

--- a/compat/libsecp256k1_shim/src/shim_extrakeys.cpp
+++ b/compat/libsecp256k1_shim/src/shim_extrakeys.cpp
@@ -23,6 +23,8 @@ using namespace secp256k1::fast;
 // point_to_pubkey_data from shim_pubkey_helpers.hpp
 using secp256k1_shim_internal::point_to_pubkey_data;
 using secp256k1_shim_internal::pubkey_data_to_point;
+// x-only / keypair derivation is fail-closed on an off-curve opaque pubkey.
+using secp256k1_shim_internal::pubkey_data_to_point_checked;
 
 // Helper: reconstruct a Point from an xonly_pubkey using cached X||Y -- no sqrt.
 // SHIM-CURVE-CHECK-XONLY: validate y^2=x^3+7 before use. A hostile caller could
@@ -128,7 +130,7 @@ int secp256k1_xonly_pubkey_from_pubkey(
 
     // SHIM-A10: validate curve membership before trusting the stored bytes.
     // pubkey_data_to_point checks y²=x³+7; returns infinity if off-curve.
-    auto pt = pubkey_data_to_point(pubkey->data);
+    auto pt = pubkey_data_to_point_checked(pubkey->data);
     if (pt.is_infinity()) { std::memset(xonly_pubkey->data, 0, sizeof(xonly_pubkey->data)); return 0; }
 
     // pubkey layout: data[0..31] = X, data[32..63] = Y (both big-endian)
@@ -244,7 +246,7 @@ int secp256k1_keypair_pub(
         secp256k1_shim_call_illegal_cb(ctx, "secp256k1_keypair_pub: keypair is NULL");
         return 0;
     }
-    auto P = pubkey_data_to_point(keypair->data + 32);
+    auto P = pubkey_data_to_point_checked(keypair->data + 32);
     if (P.is_infinity()) { std::memset(pubkey->data, 0, sizeof(pubkey->data)); return 0; }
     std::memcpy(pubkey->data, keypair->data + 32, 64);
     return 1;
@@ -263,7 +265,7 @@ int secp256k1_keypair_xonly_pub(
         secp256k1_shim_call_illegal_cb(ctx, "secp256k1_keypair_xonly_pub: keypair is NULL");
         return 0;
     }
-    auto P = pubkey_data_to_point(keypair->data + 32);
+    auto P = pubkey_data_to_point_checked(keypair->data + 32);
     if (P.is_infinity()) {
         std::memset(pubkey->data, 0, sizeof(pubkey->data));
         if (pk_parity) *pk_parity = 0;

--- a/compat/libsecp256k1_shim/src/shim_pubkey.cpp
+++ b/compat/libsecp256k1_shim/src/shim_pubkey.cpp
@@ -23,6 +23,9 @@ using namespace secp256k1::fast;
 // point_to_pubkey_data and pubkey_data_to_point from shim_pubkey_helpers.hpp
 using secp256k1_shim_internal::point_to_pubkey_data;
 using secp256k1_shim_internal::pubkey_data_to_point;
+// Manipulation / serialization paths use the curve-checked loader (fail-closed on
+// an off-curve / malformed opaque pubkey); the hot verify paths use the unchecked one.
+using secp256k1_shim_internal::pubkey_data_to_point_checked;
 
 // -- Thread-local pubkey-parse (decompression) cache --------------------------
 // PERF: parsing a COMPRESSED pubkey computes y = sqrt(x^3 + 7) — a full field
@@ -181,7 +184,7 @@ int secp256k1_ec_pubkey_serialize(
         secp256k1_shim_call_illegal_cb(ctx, "secp256k1_ec_pubkey_serialize: invalid flags");
         return 0;
     }
-    auto P = pubkey_data_to_point(pubkey->data);
+    auto P = pubkey_data_to_point_checked(pubkey->data);
     if (P.is_infinity()) {
         *outputlen = 0;
         return 0;
@@ -272,7 +275,7 @@ int secp256k1_ec_pubkey_negate(
         secp256k1_shim_call_illegal_cb(ctx, "secp256k1_ec_pubkey_negate: pubkey is NULL");
         return 0;
     }
-    auto P = pubkey_data_to_point(pubkey->data);
+    auto P = pubkey_data_to_point_checked(pubkey->data);
     if (P.is_infinity()) {
         std::memset(pubkey->data, 0, sizeof(pubkey->data));
         return 0;
@@ -295,7 +298,7 @@ int secp256k1_ec_pubkey_tweak_add(
         secp256k1_shim_call_illegal_cb(ctx, "secp256k1_ec_pubkey_tweak_add: tweak32 is NULL");
         return 0;
     }
-    auto P = pubkey_data_to_point(pubkey->data);
+    auto P = pubkey_data_to_point_checked(pubkey->data);
     if (P.is_infinity()) { std::memset(pubkey->data, 0, sizeof(pubkey->data)); return 0; }
     // tweak in [0, n-1]; 0 is valid (result == pubkey)
     Scalar t;
@@ -320,7 +323,7 @@ int secp256k1_ec_pubkey_tweak_mul(
         secp256k1_shim_call_illegal_cb(ctx, "secp256k1_ec_pubkey_tweak_mul: tweak32 is NULL");
         return 0;
     }
-    auto P = pubkey_data_to_point(pubkey->data);
+    auto P = pubkey_data_to_point_checked(pubkey->data);
     Scalar t;
     if (P.is_infinity()) { std::memset(pubkey->data, 0, sizeof(pubkey->data)); return 0; }
     if (!Scalar::parse_bytes_strict_nonzero(tweak32, t)) { std::memset(pubkey->data, 0, sizeof(pubkey->data)); return 0; }
@@ -350,10 +353,10 @@ int secp256k1_ec_pubkey_combine(
             return 0;
         }
     }
-    auto acc = pubkey_data_to_point(ins[0]->data);
+    auto acc = pubkey_data_to_point_checked(ins[0]->data);
     if (acc.is_infinity()) { std::memset(out->data, 0, sizeof(out->data)); return 0; }
     for (size_t i = 1; i < n; ++i) {
-        auto P = pubkey_data_to_point(ins[i]->data);
+        auto P = pubkey_data_to_point_checked(ins[i]->data);
         if (P.is_infinity()) { std::memset(out->data, 0, sizeof(out->data)); return 0; }
         acc = acc.add(P);
     }

--- a/compat/libsecp256k1_shim/src/shim_pubkey_helpers.hpp
+++ b/compat/libsecp256k1_shim/src/shim_pubkey_helpers.hpp
@@ -52,4 +52,25 @@ inline void point_to_pubkey_data(const Point& pt, unsigned char data[64]) noexce
     return Point::from_affine(x, y);
 }
 
+// Like pubkey_data_to_point, but ADDITIONALLY enforces EC curve membership
+// (y² == x³ + 7) and returns infinity for an off-curve (incl. all-zero) opaque
+// pubkey. Used by the pubkey MANIPULATION / serialization / derivation paths
+// (negate, serialize, tweak_add/mul, combine, x-only / keypair extraction) so they
+// stay FAIL-CLOSED on a malformed `secp256k1_pubkey` struct — a deliberately
+// libsecp-stricter guardrail (see audit/test_regression_p2_ct_shim_fixes.cpp:
+// SHIM-FC / NEG-002). The HOT verify paths (ecdsa/schnorr verify + batch) keep the
+// unchecked pubkey_data_to_point: curve membership is validated once at parse and
+// the per-call re-check there is pure overhead (PERF-002 / c67edc1c). The curve
+// equation costs ~1S+2M, negligible off the verify hot loop.
+[[nodiscard]] inline Point pubkey_data_to_point_checked(const unsigned char data[64]) noexcept {
+    const auto& xb = *reinterpret_cast<const std::array<uint8_t, 32>*>(data);
+    const auto& yb = *reinterpret_cast<const std::array<uint8_t, 32>*>(data + 32);
+    FieldElement x, y;
+    if (!FieldElement::parse_bytes_strict(xb, x)) return Point::infinity();
+    if (!FieldElement::parse_bytes_strict(yb, y)) return Point::infinity();
+    FieldElement const b7 = FieldElement::from_uint64(7);
+    if (y * y != x * x * x + b7) return Point::infinity();   // off-curve / (0,0)
+    return Point::from_affine(x, y);
+}
+
 } // namespace secp256k1_shim_internal

--- a/docs/AUDIT_CHANGELOG.md
+++ b/docs/AUDIT_CHANGELOG.md
@@ -1,5 +1,22 @@
 # Audit Changelog
 
+## 2026-06-16 — Shim pubkey manipulation paths fail-closed on off-curve (PERF-002 split)
+
+- **`regression_p2_ct_shim_fixes` was failing on clang/MSVC** (passed on gcc) after the
+  PERF-002 curve-check removal (`daf4aa45`) took the `y²=x³+7` check out of the SHARED
+  `pubkey_data_to_point`, which also serves the pubkey MANIPULATION paths — so
+  `pubkey_negate` / `pubkey_serialize` / `tweak_add` / `tweak_mul` / `combine` /
+  x-only+keypair derivation silently processed an off-curve / all-zero opaque pubkey
+  instead of rejecting it (a clang/compiler-dependent CA-001-class divergence).
+- **Fix (Option A — split the loader):** added `pubkey_data_to_point_checked`
+  (re-enforces `y²=x³+7`, returns infinity for off-curve/(0,0)). Routed ONLY the
+  manipulation/derivation paths to it (fail-closed restored); the HOT verify paths
+  (ecdsa/schnorr verify + batch) keep the unchecked `pubkey_data_to_point` so
+  PERF-002's verify speedup is preserved (curve membership is validated once at parse).
+- Validated gcc + clang-18: `regression_p2_ct_shim_fixes` 43/0 (now also covers
+  tweak_add/tweak_mul off-curve), `regression_ecdsa_batch_curve_check` 16009/0 (verify
+  path unchanged). kb SHIM-OFFCURVE-SPLIT-20260616.
+
 ## 2026-06-16 — Windows-ARM64 (clang-cl) portability + de-masquerade install
 
 - **New regression module `regression_mul128_portability`** (math_invariants,


### PR DESCRIPTION
Re-cut #3: the desktop ctest legs (linux/macos/win-x64) failed regression_p2_ct_shim_fixes — the PERF-002 curve-check removal left the pubkey manipulation paths not fail-closed on off-curve input (clang-only). Fix: split loader (manipulation -> checked, verify -> unchecked). Validated full clang ctest green locally. Admin-merge so v4.3.0 can be re-pointed at 853fb35f.