### PR TITLE
Fix/windows msvc cuda

### DIFF
--- a/.github/workflows/windows-cuda.yml
+++ b/.github/workflows/windows-cuda.yml
@@ -1,0 +1,74 @@
+# Windows/MSVC CUDA compile + libbitcoin-direct hook retention check.
+#
+# Hosted runners have no GPU: nvcc compiles without one, and the
+# lbtc_direct_gpu_columns_hook test asserts hook INSTALLATION (a static
+# initializer retained at link), which is GPU-independent — the hook then
+# falls back to CPU at runtime. This proves /INCLUDE:... anchor retention on
+# MSVC rather than inferring it, and compiles the full Windows GPU host path
+# (historically never built on Windows: rpcndr.h 'small' collision, GNU-only
+# --undefined retention).
+name: Windows CUDA
+
+on:
+  pull_request:
+  push:
+    branches: [main, dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-cuda:
+    name: MSVC CUDA + libbitcoin-direct hook retention
+    runs-on: windows-2022
+    timeout-minutes: 60
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Install CUDA Toolkit (compile components only)
+        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
+        with:
+          method: network
+          sub-packages: '["nvcc", "cudart", "thrust", "visual_studio_integration"]'
+
+      - name: Configure (MSVC + CUDA, libbitcoin minimal-node GPU profile)
+        shell: cmd
+        run: >
+          cmake -S . -B build -G "Visual Studio 17 2022" -A x64
+          -DSECP256K1_BUILD_LIBBITCOIN=ON
+          -DSECP256K1_BUILD_LIBBITCOIN_GPU=ON
+          -DSECP256K1_BUILD_LIBBITCOIN_TESTS=ON
+          -DSECP256K1_BUILD_CUDA=ON
+          -DCMAKE_CUDA_ARCHITECTURES=89
+          -DSECP256K1_GPU_BUILD_ZK=OFF
+          -DSECP256K1_GPU_BUILD_BIP324=OFF
+          -DSECP256K1_GPU_BUILD_FROST=OFF
+          -DSECP256K1_GPU_BUILD_BIP352=OFF
+          -DSECP256K1_GPU_BUILD_ECDH=OFF
+          -DSECP256K1_GPU_BUILD_MSM=OFF
+          -DSECP256K1_GPU_BUILD_HASH160=OFF
+          -DSECP256K1_GPU_BUILD_ECRECOVER=OFF
+
+      - name: Build (engine, GPU host, kernels, macro fixture, hook test)
+        shell: cmd
+        run: >
+          cmake --build build --config Release --target
+          fastsecp256k1 secp256k1_gpu_host secp256k1_cuda_lib
+          test_windows_macro_compat test_lbtc_direct_gpu_columns_hook
+
+      - name: Test (macro fixture + hook self-install retention)
+        shell: cmd
+        run: >
+          ctest --test-dir build -C Release --output-on-failure
+          -R "cuda_windows_macro_compat|lbtc_direct_gpu_columns_hook"

--- a/compat/libbitcoin_direct/CMakeLists.txt
+++ b/compat/libbitcoin_direct/CMakeLists.txt
@@ -57,11 +57,18 @@ if(SECP256K1_BUILD_LIBBITCOIN_GPU)
         # genuine transitive deps). A blanket $<LINK_LIBRARY:WHOLE_ARCHIVE,secp256k1_gpu_host>
         # is deliberately NOT used: it would also drag in gpu_backend_fallback.o, whose
         # snark-witness CPU fallback references secp256k1::zk::* symbols that are not part of
-        # the minimal libbitcoin engine, breaking the link. Targeted -u retention pulls only
+        # the minimal libbitcoin engine, breaking the link. Targeted anchor retention
+        # (GNU/LLVM --undefined=, MSVC /INCLUDE:) pulls only
         # the hook. (The ufsecp C ABI path retains the same object via a source-level anchor
         # reference in ufsecp_gpu_impl.cpp — see src/gpu/src/gpu_engine_hook.cpp and
         # src/gpu/CMakeLists.txt "LBTC-GPU-SELFINSTALL-DROP".)
-        set(_lbtc_gpu_retain "LINKER:--undefined=secp256k1_gpu_columns_provider_anchor")
+        # MSVC link.exe has no --undefined; /INCLUDE is its targeted-retention equivalent
+        # (silently-ignored --undefined leaves the hook dead-stripped: CPU-only, no error).
+        if(MSVC)
+            set(_lbtc_gpu_retain "LINKER:/INCLUDE:secp256k1_gpu_columns_provider_anchor")
+        else()
+            set(_lbtc_gpu_retain "LINKER:--undefined=secp256k1_gpu_columns_provider_anchor")
+        endif()
         # Enable the seven libbitcoin public-data batch-op GPU trampolines in
         # gpu_engine_hook.cpp (guarded by SECP256K1_LBTC_GPU_OPS) and give that TU
         # the include path for <ufsecp/lbtc_gpu_ops.hpp>. Both are target-level
@@ -73,7 +80,7 @@ if(SECP256K1_BUILD_LIBBITCOIN_GPU)
         # EngineLbtcOpsInstaller rides the same TU/anchor as the column provider.
         target_include_directories(secp256k1_gpu_host PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
         target_compile_definitions(secp256k1_gpu_host PRIVATE SECP256K1_LBTC_GPU_OPS)
-        message(STATUS "  libbitcoin direct GPU: ON (SECP256K1_BUILD_LIBBITCOIN_GPU=ON; secp256k1_gpu_host linked, hook retained via -u anchor — transparent GPU column verify + public-data batch ops)")
+        message(STATUS "  libbitcoin direct GPU: ON (SECP256K1_BUILD_LIBBITCOIN_GPU=ON; secp256k1_gpu_host linked, hook retained via targeted anchor (${_lbtc_gpu_retain}) — transparent GPU column verify + public-data batch ops)")
     else()
         set(_lbtc_gpu_host "")
         set(_lbtc_gpu_retain "")

--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -133,6 +133,20 @@ set_tests_properties(bip324_kat_cuda PROPERTIES
     TIMEOUT 60
     LABELS "gpu;cuda;kat;bip324;chacha20;rfc8439")
 
+# ===== Windows macro compatibility compile fixture =====
+# Deterministic regression for the rpcndr.h `small` macro collision: compiles
+# secp256k1.cuh with the macro pre-defined (see test_windows_macro_compat.cu).
+# The compile itself is the test; the executable is a trivial exit.
+add_executable(test_windows_macro_compat src/test_windows_macro_compat.cu)
+target_include_directories(test_windows_macro_compat PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+)
+add_test(NAME cuda_windows_macro_compat COMMAND test_windows_macro_compat)
+set_tests_properties(cuda_windows_macro_compat PROPERTIES
+    TIMEOUT 60
+    LABELS "gpu;cuda;compat;windows")
+
 # ===== GPU Unified Audit Runner =====
 set(_AUDIT_SOURCES src/gpu_audit_runner.cu)
 if(_GPU_LANG STREQUAL "HIP")

--- a/src/cuda/include/secp256k1.cuh
+++ b/src/cuda/include/secp256k1.cuh
@@ -1229,16 +1229,17 @@ __device__ inline void field_negate(const FieldElement* a, FieldElement* r) {
 }
 #endif
 
-// Field multiplication by small constant: r = a * small (mod P)
+// Field multiplication by small constant: r = a * factor (mod P)
 // Optimized for small constants (e.g., 7, 28 for secp256k1)
-__device__ inline void field_mul_small(const FieldElement* a, uint32_t small, FieldElement* r) {
+// NOTE: parameter deliberately not named "small" — Windows rpcndr.h #defines small as char.
+__device__ inline void field_mul_small(const FieldElement* a, uint32_t factor, FieldElement* r) {
     // Simple approach: multiply and reduce
     // For small constants, this is faster than full field_mul
     uint64_t carry = 0;
     uint64_t tmp[4];
     
     for (int i = 0; i < 4; i++) {
-        tmp[i] = muladd64(a->limbs[i], static_cast<uint64_t>(small), 0, carry);
+        tmp[i] = muladd64(a->limbs[i], static_cast<uint64_t>(factor), 0, carry);
     }
     
     // Now we have a 320-bit number: tmp[0..3] + carry * 2^256

--- a/src/cuda/src/test_windows_macro_compat.cu
+++ b/src/cuda/src/test_windows_macro_compat.cu
@@ -1,0 +1,16 @@
+// ===== Windows macro compatibility compile fixture =====
+// Windows rpcndr.h (pulled in by windows.h without WIN32_LEAN_AND_MEAN, e.g.
+// via secure_erase.hpp) defines `small` as `char`, which rewrites any
+// identifier named `small` in subsequently-included headers into invalid
+// syntax. This broke every Windows GPU-host TU including secp256k1.cuh after
+// a Windows header. Pre-defining the macro here makes the collision
+// deterministic on ALL platforms: this TU fails to compile if an identifier
+// colliding with the rpcndr.h macro set is reintroduced.
+#define small char
+
+#include "secp256k1.cuh"
+
+int main()
+{
+    return 0;
+}

--- a/src/gpu/src/gpu_engine_hook.cpp
+++ b/src/gpu/src/gpu_engine_hook.cpp
@@ -45,8 +45,11 @@
  *   - the ufsecp C ABI (src/cpu/src/ufsecp_gpu_impl.cpp) references it, dragging
  *     this object into libufsecp so the ufsecp/audit path installs the hook;
  *   - the libbitcoin-direct path references no gpu_host symbol, so its executables
- *     force this object in with a linker `--undefined=secp256k1_gpu_columns_provider_anchor`
- *     at their own link (compat/libbitcoin_direct/CMakeLists.txt). Targeted -u
+ *     force this object in with a platform-specific targeted linker retention of
+ *     `secp256k1_gpu_columns_provider_anchor` at their own link — GNU/LLVM
+ *     `--undefined=`, MSVC `/INCLUDE:` (which link.exe requires; it silently
+ *     ignores `--undefined=`, dead-stripping the hook: CPU-only, no error) — see
+ *     compat/libbitcoin_direct/CMakeLists.txt. Targeted anchor
  *     retention is preferred over a blanket WHOLE_ARCHIVE: it pulls only this
  *     provider object, not every backend TU. (WHOLE_ARCHIVE historically also broke
  *     the ZK-less link by dragging in gpu_backend_fallback.o and its undefined


### PR DESCRIPTION
Two fixes that make the GPU host layer compile and function on Windows/MSVC:

1. **cuda: avoid Windows rpcndr.h 'small' macro** — `windows.h` (included via
   `secure_erase.hpp` on `_WIN32`) pulls in `rpcndr.h`, which `#define small char`.
   Any TU including the CUDA headers after a Windows header fails to compile
   (`gpu_backend_cuda.cu`: "invalid combination of type specifiers"). Renames the
   `field_mul_small` parameter to `factor`.

2. **build: retain libbitcoin GPU hook with /INCLUDE under MSVC** — the
   self-installing `GpuColumnsVerifyHook` is retained via `LINKER:--undefined=...`,
   which is GNU-ld syntax. MSVC link.exe silently ignores it and dead-strips the
   hook object, so transparent GPU column verify silently stays CPU-only. Uses
   `/INCLUDE:secp256k1_gpu_columns_provider_anchor` on MSVC.

Verified on Windows 11 / VS 18 (v145) / CUDA 13.3 / RTX PRO 6000 (sm_120), built with
`SECP256K1_BUILD_LIBBITCOIN=ON`, `SECP256K1_BUILD_LIBBITCOIN_GPU=ON`,
`SECP256K1_BUILD_CUDA=ON`, all `SECP256K1_GPU_BUILD_*` modules OFF (minimal node GPU
surface):

- `lbtc_direct_verify`, `lbtc_direct_operations`, `lbtc_direct_gpu_columns_hook`
  all pass.
- `bench_lbtc_direct_batch` (1M sigs): 23.6 M sig/s ECDSA / 29.3 M sig/s Schnorr
  via the transparent GPU columns path; CPU row path ~2.0–2.6 M sig/s at 128
  threads.

Suggestion (not included in this PR): a compile-only `windows-cuda` CI job would
have caught both issues — hosted runners need no GPU to compile CUDA, and the
existing GPU CI (self-hosted runner, cuda-intrinsic-check) is Linux-only.