### PR TITLE
cuda: match __restrict__ on cross-TU kernel declarations (MSVC LNK2019)

### DIFF
--- a/src/cuda/src/bench_cuda.cu
+++ b/src/cuda/src/bench_cuda.cu
@@ -812,24 +812,37 @@ BenchResult bench_jacobian_to_affine(const BenchConfig& cfg) {
 
 // Forward-declare batch kernels (defined in secp256k1.cu, namespace secp256k1::cuda)
 namespace secp256k1 { namespace cuda {
+/* Declarations must match the kernel definitions' __restrict__ qualifiers
+ * exactly: MSVC mangles __restrict into the symbol name (Itanium does not),
+ * so bare declarations link on gcc/clang but fail with LNK2019 on MSVC. */
 extern __global__ void ecdsa_sign_batch_kernel(
-    const uint8_t*, const Scalar*, ECDSASignatureGPU*, bool*, int);
+    const uint8_t* __restrict__, const Scalar* __restrict__,
+    ECDSASignatureGPU* __restrict__, bool* __restrict__, int);
 extern __global__ void ecdsa_verify_batch_kernel(
-    const uint8_t*, const JacobianPoint*, const uint8_t*, bool*, int);
+    const uint8_t* __restrict__, const JacobianPoint* __restrict__,
+    const uint8_t* __restrict__, bool* __restrict__, int);
 extern __global__ void schnorr_sign_batch_kernel(
-    const Scalar*, const uint8_t*, const uint8_t*, SchnorrSignatureGPU*, bool*, int);
+    const Scalar* __restrict__, const uint8_t* __restrict__,
+    const uint8_t* __restrict__, SchnorrSignatureGPU* __restrict__,
+    bool* __restrict__, int);
 extern __global__ void schnorr_verify_batch_kernel(
-    const uint8_t*, const uint8_t*, const SchnorrSignatureGPU*, bool*, int);
+    const uint8_t* __restrict__, const uint8_t* __restrict__,
+    const SchnorrSignatureGPU* __restrict__, bool* __restrict__, int);
 extern __global__ void ecdsa_sign_recoverable_batch_kernel(
-    const uint8_t*, const Scalar*, RecoverableSignatureGPU*, bool*, int);
+    const uint8_t* __restrict__, const Scalar* __restrict__,
+    RecoverableSignatureGPU* __restrict__, bool* __restrict__, int);
 extern __global__ void ecdsa_recover_batch_kernel(
-    const uint8_t*, const ECDSASignatureGPU*, const int*, JacobianPoint*, bool*, int);
+    const uint8_t* __restrict__, const ECDSASignatureGPU* __restrict__,
+    const int* __restrict__, JacobianPoint* __restrict__,
+    bool* __restrict__, int);
 extern __global__ void frost_verify_partial_batch_kernel(
-    const uint8_t*, const uint8_t*, const uint8_t*, const uint8_t*,
-    const uint8_t*, const uint8_t*, const uint8_t*, const uint8_t*,
-    uint8_t*, int);
+    const uint8_t* __restrict__, const uint8_t* __restrict__,
+    const uint8_t* __restrict__, const uint8_t* __restrict__,
+    const uint8_t* __restrict__, const uint8_t* __restrict__,
+    const uint8_t* __restrict__, const uint8_t* __restrict__,
+    uint8_t* __restrict__, int);
 extern __global__ void batch_jacobian_to_compressed_kernel(
-    const JacobianPoint*, uint8_t*, int);
+    const JacobianPoint* __restrict__, uint8_t* __restrict__, int);
 }} // namespace secp256k1::cuda
 
 // Helper: generate test keys and sign messages on GPU for verify benchmarks

--- a/src/gpu/src/gpu_backend_cuda.cu
+++ b/src/gpu/src/gpu_backend_cuda.cu
@@ -117,10 +117,20 @@ extern __global__ void schnorr_verify_collect_kernel(
     const SchnorrSignatureGPU* __restrict__ sigs,
     uint8_t*       __restrict__ key_cells,
     int count);
+/* Declaration must match the kernel definition's __restrict__ qualifiers
+ * exactly: MSVC mangles __restrict into the symbol name (Itanium does not),
+ * so a bare declaration links on gcc/clang but fails with LNK2019 on MSVC. */
 extern __global__ void frost_verify_partial_batch_kernel(
-    const uint8_t*, const uint8_t*, const uint8_t*, const uint8_t*,
-    const uint8_t*, const uint8_t*, const uint8_t*, const uint8_t*,
-    uint8_t*, int);
+    const uint8_t* __restrict__ z_i_bytes,
+    const uint8_t* __restrict__ D_i_bytes,
+    const uint8_t* __restrict__ E_i_bytes,
+    const uint8_t* __restrict__ Y_i_bytes,
+    const uint8_t* __restrict__ rho_i_bytes,
+    const uint8_t* __restrict__ lambda_i_e_bytes,
+    const uint8_t* __restrict__ negate_R,
+    const uint8_t* __restrict__ negate_key,
+    uint8_t*       __restrict__ results,
+    int count);
 extern __global__ void ecdsa_recover_batch_kernel(
     const uint8_t* __restrict__ msg_hashes,
     const ECDSASignatureGPU* __restrict__ sigs,


### PR DESCRIPTION
## Summary

The documented libbitcoin GPU build
(`-DSECP256K1_BUILD_LIBBITCOIN=ON -DSECP256K1_BUILD_LIBBITCOIN_GPU=ON
-DSECP256K1_BUILD_CUDA=ON`) fails to link on MSVC with the default GPU module
set:

```
gpu_backend_cuda.cu.obj : error LNK2019: unresolved external symbol
  secp256k1::cuda::frost_verify_partial_batch_kernel(...)
```

All three `lbtc_direct*` executables fail. Linux/macOS are unaffected.

## Root cause

MSVC mangles `__restrict` into the symbol name; the Itanium ABI drops
top-level parameter qualifiers. The kernel definitions in
`src/cuda/src/secp256k1.cu` carry `__restrict__` on every pointer parameter,
but some cross-TU `extern __global__` declarations were written bare:

- Definition mangles as `...PEIBE...` (`unsigned char const * __restrict`)
- Bare declaration references `...PEBE...` (`unsigned char const *`)

Same name on gcc/clang, two different symbols on MSVC → LNK2019.

Symbol-table cross-check (dumpbin, every UNDEF kernel symbol in each consumer
vs. defined symbols in `secp256k1.cu.obj`) found the complete defect set:

- `src/gpu/src/gpu_backend_cuda.cu` — 1 of 8 declarations bare (`frost_verify_partial_batch_kernel`; breaks the libbitcoin GPU profile)
- `src/cuda/src/bench_cuda.cu` — all 8 declarations bare (latent; breaks any Windows CUDA bench build)

These are the only two files with `extern __global__` declarations in the tree.

## Fix

Add `__restrict__` to the declarations to match the definitions exactly.
Definitions unchanged (`__restrict__` on kernel params is a real device-codegen
hint). One comment at each declaration site records the MSVC-mangling
constraint so the mismatch doesn't get reintroduced.

## Verified (Windows 11, MSVC 14.51/v145, CUDA 13.3, RTX PRO 6000)

- Baseline: the parent commit (`2d6de776`), built clean-worktree with identical
  flags, reproduces the identical failure — confirming this is pre-existing,
  not introduced by recent work.
- After fix, the previously failing config links 19/19 and all three tests
  pass on real hardware: `test_lbtc_direct_verify`,
  `test_lbtc_direct_operations`, `test_lbtc_direct_gpu_columns_hook`.
- `secp256k1_cuda_bench` (CUDA + `SECP256K1_BUILD_BENCH=ON`) now links,
  covering the eight bench-side declarations.

Note: this defect also exists upstream (shrec/UltrafastSecp256k1 `dev`) — the
Windows CUDA CI leg is compile-only, which is why it never surfaced there.
Worth forwarding.
