### PR TITLE
Add caller-visible GPU availability query for libbitcoin-direct columns verify

### DIFF
--- a/compat/libbitcoin_direct/include/ufsecp/libbitcoin.hpp
+++ b/compat/libbitcoin_direct/include/ufsecp/libbitcoin.hpp
@@ -184,6 +184,25 @@ inline constexpr const char* fastsecp256k1_libbitcoin_target() noexcept {
         digests32, xonly32, sigs64, count, out_results, max_threads);
 }
 
+// ─── GPU availability query (discovery only, not a verify-path switch) ──────
+// True iff GPU offload is actually possible for ecdsa_verify_columns /
+// schnorr_verify_columns on this process (a GPU-host provider is linked AND a
+// working device was found). A caller that would otherwise spend a pass
+// marshalling digests/points/sigs into the contiguous column layout only to
+// hand it to the verify call above -- even on a box with no GPU -- can check
+// this first and skip that marshalling path entirely when it is false.
+//
+// This does NOT gate or change ecdsa_verify_columns / schnorr_verify_columns
+// themselves: they keep the existing "no caller-visible CPU/GPU split"
+// contract and fall back to the CPU column path transparently either way,
+// regardless of what this function returns. It is advisory, and its answer
+// can go stale between this call and the next batch (a device disappearing
+// mid-process); the verify path's own fallback is what keeps that safe, not
+// this check.
+[[nodiscard]] inline bool gpu_available() noexcept {
+    return secp256k1::gpu_columns_available();
+}
+
 // ══════════════════════════════════════════════════════════════════════════════
 // ECDSA Signing  (CT-backed — all secret-bearing paths use ct::* primitives)
 // ══════════════════════════════════════════════════════════════════════════════

--- a/compat/libbitcoin_direct/include/ufsecp/libbitcoin.hpp
+++ b/compat/libbitcoin_direct/include/ufsecp/libbitcoin.hpp
@@ -185,6 +185,9 @@ inline constexpr const char* fastsecp256k1_libbitcoin_target() noexcept {
 }
 
 // ─── GPU availability query (discovery only, not a verify-path switch) ──────
+// Feature-test macro: consumers key compilation on this so the same source
+// builds against older ufsecp headers that lack gpu_available().
+#define UFSECP_LBTC_HAS_GPU_AVAILABLE 1
 // True iff GPU offload is actually possible for ecdsa_verify_columns /
 // schnorr_verify_columns on this process (a GPU-host provider is linked AND a
 // working device was found). A caller that would otherwise spend a pass

--- a/compat/libbitcoin_direct/tests/test_direct_gpu_columns_hook.cpp
+++ b/compat/libbitcoin_direct/tests/test_direct_gpu_columns_hook.cpp
@@ -3,16 +3,20 @@
 // C ABI audit path) so the direct-GPU opt-in profile carries its own acceptance
 // smoke, visible in `ctest -N` / target help as `lbtc_direct_gpu_columns_hook`.
 //
-// It asserts the engine's GpuColumnsVerifyHook is self-installed at process
-// startup — BEFORE this test installs any double — by the GPU-host self-installer
-// (EngineGpuColumnsInstaller in secp256k1_gpu_host), which this executable retains
-// at link via the targeted `--undefined=secp256k1_gpu_columns_provider_anchor`
-// anchor. A null hook here means that provider object was dropped at link and
-// "transparent GPU column verify" silently degraded to CPU-only — exactly what
-// this smoke guards. It then runs a small valid column batch through the unified
-// engine call (GPU when a device exists, transparent CPU fallback otherwise) and
-// a tampered-row fail-closed check — all through the ONE caller-visible API, with
-// no CPU/GPU split and no caller-visible GPU status.
+// It asserts the engine's GpuColumnsVerifyHook AND its sibling
+// GpuColumnsAvailableHook (caller-visible discovery, ufsecp::lbtc::gpu_available())
+// are self-installed at process startup — BEFORE this test installs any double —
+// by the GPU-host self-installer (EngineGpuColumnsInstaller in secp256k1_gpu_host),
+// which this executable retains at link via the targeted
+// `--undefined=secp256k1_gpu_columns_provider_anchor` anchor. A null hook here
+// means that provider object was dropped at link and "transparent GPU column
+// verify" (and the availability query) silently degraded to CPU-only — exactly
+// what this smoke guards. It then runs a small valid column batch through the
+// unified engine call (GPU when a device exists, transparent CPU fallback
+// otherwise) and a tampered-row fail-closed check — all through the ONE
+// caller-visible verify API, with no CPU/GPU split and no caller-visible GPU
+// status; the availability query is a separate, narrower discovery-only check
+// (see GpuColumnsAvailableHook in secp256k1/batch_verify.hpp).
 //
 // Build: linked only in the SECP256K1_BUILD_LIBBITCOIN_GPU profile with a GPU
 // backend compiled (see compat/libbitcoin_direct/CMakeLists.txt). Returns 0 on
@@ -51,6 +55,19 @@ int main() {
     secp256k1::install_gpu_columns_verify_hook(startup_hook);  // restore immediately
     check(startup_hook != nullptr,
           "GpuColumnsVerifyHook self-installed at startup by secp256k1_gpu_host (provider TU retained)");
+
+    // (1b) Same startup assertion for the sibling availability-query hook: it
+    // installs in the SAME constructor as the verify hook above, so a non-null
+    // capture here is just as much a proof the provider TU is retained. This also
+    // exercises the ufsecp::lbtc::gpu_available() call site libbitcoin-direct
+    // callers are meant to use before marshalling a batch.
+    secp256k1::GpuColumnsAvailableHook startup_available_hook =
+        secp256k1::install_gpu_available_query_hook(nullptr);
+    secp256k1::install_gpu_available_query_hook(startup_available_hook);  // restore immediately
+    check(startup_available_hook != nullptr,
+          "GpuColumnsAvailableHook self-installed at startup by secp256k1_gpu_host (provider TU retained)");
+    check(secp256k1::gpu_columns_available() == ufsecp::lbtc::gpu_available(),
+          "secp256k1::gpu_columns_available() and ufsecp::lbtc::gpu_available() agree");
 
     // (2) Transparent accelerated path: a small valid ECDSA + Schnorr column batch
     // through the unified engine surface. With the hook installed the engine

--- a/docs/LIBBITCOIN_INTEGRATION.md
+++ b/docs/LIBBITCOIN_INTEGRATION.md
@@ -167,6 +167,34 @@ GPU column verify is available when:
 - At least one GPU backend (CUDA/OpenCL/Metal) is compiled
 - A compatible GPU runtime is available at startup
 
+**Caller-visible availability query (narrow, additive exception to contract 1):**
+
+`ufsecp::lbtc::gpu_available()` (`<ufsecp/libbitcoin.hpp>`) answers exactly one
+question: is GPU offload for the columns verify path actually active on this
+process. It exists so a caller can skip *building* a batch — marshalling
+digests/points/sigs into the contiguous column layout — when no GPU is present,
+rather than paying that cost only to have the verify hook decline it anyway.
+
+This is deliberately scoped narrower than it might look:
+- It does **not** change `ecdsa_verify_columns` / `schnorr_verify_columns`
+  themselves. Both keep contract 1's "no caller-visible CPU/GPU split" in full —
+  they fall back to the CPU column path transparently regardless of whether the
+  caller checked availability first, checked it and got a stale answer, or never
+  checked at all.
+- It cannot select, force, or disable a backend. It is read-only discovery.
+- It is advisory: the device state it reports can change between this call and
+  the next batch. Safety still comes from the verify path's own fallback, not
+  from calling this first.
+
+Implementation: a second hook, `GpuColumnsAvailableHook`
+(`secp256k1/batch_verify.hpp`), installed by the SAME `EngineGpuColumnsInstaller`
+static initializer as `GpuColumnsVerifyHook` (`gpu_engine_hook.cpp`) — same
+enablement condition ("is `secp256k1_gpu_host` linked"), same retained-anchor
+mechanism, and it reuses the verify hook's cached device probe rather than
+re-probing. `secp256k1::gpu_columns_available()` is the engine-level convenience
+wrapper; `ufsecp::lbtc::gpu_available()` is the libbitcoin-direct call site.
+Covered by the same `lbtc_direct_gpu_columns_hook` smoke test.
+
 When any of these conditions is not met, the engine falls back transparently
 to the deterministic CPU column path.
 

--- a/src/cpu/include/secp256k1/batch_verify.hpp
+++ b/src/cpu/include/secp256k1/batch_verify.hpp
@@ -167,6 +167,36 @@ using GpuColumnsVerifyHook = int (*)(int kind,
 // Install (nullptr clears). Thread-safe. Returns the previous hook (save/restore).
 GpuColumnsVerifyHook install_gpu_columns_verify_hook(GpuColumnsVerifyHook hook) noexcept;
 
+// -- GPU availability query hook (caller-visible discovery, verify-path opt-out only) ---
+// Null by default (pure CPU). Self-installed alongside GpuColumnsVerifyHook, by the
+// same static initializer in the GPU-host layer (src/gpu/src/gpu_engine_hook.cpp).
+//
+// This is a SEPARATE, read-only capability query -- it does not participate in
+// verification and does not weaken the "no caller-visible CPU/GPU split" contract
+// of the verify path itself (see docs/LIBBITCOIN_INTEGRATION.md): a hook decline
+// inside *_batch_verify_*_columns is still never surfaced, and this query cannot
+// be used to select or force a backend. Its only purpose is to let a caller
+// decide, BEFORE marshalling a batch into the column layout, whether GPU offload
+// is even possible on this process -- so it can skip that marshalling step
+// entirely when it is not, rather than paying to build a batch that the verify
+// hook would only decline anyway.
+//
+// Returns 1 if a GPU backend is compiled in AND a working device was found on this
+// process, 0 otherwise. The underlying probe is performed once and cached (see
+// engine_gpu_backend() in gpu_engine_hook.cpp), so repeated queries are cheap.
+using GpuColumnsAvailableHook = int (*)() noexcept;
+
+// Install (nullptr clears). Thread-safe. Returns the previous hook (save/restore).
+GpuColumnsAvailableHook install_gpu_available_query_hook(GpuColumnsAvailableHook hook) noexcept;
+
+// Convenience: true iff a GPU-host provider is linked AND has a working device.
+// False in any CPU-only build (gpu_engine_hook.cpp not linked) and in a GPU-host
+// build where no compiled backend found a usable device. Advisory only: a caller
+// that checks this and then batches is not immune to a device becoming unavailable
+// between the check and the call -- the *_batch_verify_*_columns entrypoints still
+// fall back to the CPU column path transparently either way.
+[[nodiscard]] bool gpu_columns_available() noexcept;
+
 // -- Identify Invalid Signatures ----------------------------------------------
 
 // After a batch fails, identify which signature(s) are invalid.

--- a/src/cpu/src/batch_verify.cpp
+++ b/src/cpu/src/batch_verify.cpp
@@ -45,6 +45,23 @@ GpuColumnsVerifyHook install_gpu_columns_verify_hook(GpuColumnsVerifyHook hook) 
     return g_gpu_columns_hook.exchange(hook, std::memory_order_acq_rel);
 }
 
+// -- GPU availability query hook -----------------------------------------------
+// Sibling of the hook above, for caller-visible discovery only (see
+// GpuColumnsAvailableHook in secp256k1/batch_verify.hpp for the full contract).
+// Null by default; self-installed by the same GPU-host static initializer that
+// installs g_gpu_columns_hook.
+namespace { std::atomic<GpuColumnsAvailableHook> g_gpu_available_hook{nullptr}; }
+GpuColumnsAvailableHook install_gpu_available_query_hook(GpuColumnsAvailableHook hook) noexcept {
+    return g_gpu_available_hook.exchange(hook, std::memory_order_acq_rel);
+}
+
+bool gpu_columns_available() noexcept {
+    if (GpuColumnsAvailableHook hook = g_gpu_available_hook.load(std::memory_order_acquire)) {
+        return hook() == 1;
+    }
+    return false;
+}
+
 namespace detail {
 // Single process-wide persistent worker pool, lazily created on first batch-verify _mt
 // call and reused thereafter (no per-call thread spawn).

--- a/src/gpu/src/gpu_engine_hook.cpp
+++ b/src/gpu/src/gpu_engine_hook.cpp
@@ -21,6 +21,15 @@
  * An operational backend error is ALWAYS a decline (-1), never invalid rows
  * (fatal-not-invalid). Each backend method owns memory-bounded chunking, so the
  * full count is safe to pass straight through.
+ *
+ * This TU also self-installs a second, narrower hook: GpuColumnsAvailableHook.
+ * It answers one question -- "is a working GPU device present on this process" --
+ * so a caller can skip marshalling a batch into column layout at all when the
+ * answer is no, instead of building the batch and letting the verify hook above
+ * decline it. It reuses the SAME cached backend probe as the verify hook (no
+ * extra device I/O) and carries none of the verify path's CPU/GPU-split
+ * guarantees -- it is pure discovery, consulted only by a caller that chooses
+ * to call it before batching, never by the verify entrypoints themselves.
  * ============================================================================ */
 
 #include "secp256k1/batch_verify.hpp"   /* GpuColumnsVerifyHook + installer */
@@ -102,12 +111,30 @@ int engine_gpu_columns_hook(int kind, const std::uint8_t* digests32,
     }
 }
 
+/* Availability query trampoline for GpuColumnsAvailableHook (see
+ * secp256k1/batch_verify.hpp). Reuses the SAME lazy-probe/cache backend as
+ * engine_gpu_columns_hook above -- this never re-probes the device, it just
+ * reports whether the earlier (or this, if first) probe found one. Advisory
+ * only: never throws, never blocks on device I/O beyond the one-time probe. */
+int engine_gpu_columns_available_hook() noexcept {
+    try {
+        std::lock_guard<std::mutex> lk(g_engine_gpu_backend_mtx);
+        return engine_gpu_backend() != nullptr ? 1 : 0;
+    } catch (...) {
+        return 0;  /* treat any probe failure as "no GPU" -- advisory, never throws */
+    }
+}
+
 /* Self-install at load time. When this TU is linked (GPU host built) the engine
  * column entrypoints acquire a non-null hook automatically; a caller may still
- * override with secp256k1::install_gpu_columns_verify_hook(). */
+ * override with secp256k1::install_gpu_columns_verify_hook(). The availability
+ * query hook installs alongside it so a caller-visible discovery check is
+ * available under the exact same enablement condition as the verify hook
+ * itself ("is this provider TU linked"). */
 struct EngineGpuColumnsInstaller {
     EngineGpuColumnsInstaller() noexcept {
         secp256k1::install_gpu_columns_verify_hook(&engine_gpu_columns_hook);
+        secp256k1::install_gpu_available_query_hook(&engine_gpu_columns_available_hook);
     }
 };
 EngineGpuColumnsInstaller g_engine_gpu_columns_installer;


### PR DESCRIPTION
## Summary

libbitcoin-direct callers currently have no way to know, *before* marshalling a
batch into the column layout, whether GPU offload is even possible on this
process. `GpuColumnsVerifyHook` is only consulted inside the verify call itself,
after the batch is already built — so a CPU-only box still pays to construct the
digests/points/sigs column arrays for every batch, even though the hook will
just decline.

- Add a sibling hook, `GpuColumnsAvailableHook` (`secp256k1/batch_verify.hpp`),
  installed by the same self-installing provider (`gpu_engine_hook.cpp`)
  alongside the existing verify hook, in the same `EngineGpuColumnsInstaller`
  constructor. It reuses the verify hook's cached device probe — no extra device
  I/O, no new enablement condition, no new link anchor.
- Expose it as `secp256k1::gpu_columns_available()` at the engine level and
  `ufsecp::lbtc::gpu_available()` at the libbitcoin-direct call site
  (`ufsecp/libbitcoin.hpp`).
- Extend `test_direct_gpu_columns_hook.cpp` with the matching startup assertion
  (mirrors the existing `GpuColumnsVerifyHook` proof-of-retention check) plus a
  consistency check between the two call sites.
- Document it in `docs/LIBBITCOIN_INTEGRATION.md` as a narrow, additive
  exception to the existing "no caller-visible CPU/GPU split" contract:
  read-only pre-batch discovery that does **not** change
  `ecdsa_verify_columns` / `schnorr_verify_columns` themselves.

## Why

From a libbitcoin-side review: libbitcoin wants to skip GPU batching setup
entirely when no supported GPU is present, rather than relying on the
transparent CPU downgrade after the fact. This closes that gap without touching
the verify path's behavior or guarantees.

## Test plan — verified locally

Windows 11, VS 18 (v145 / MSVC 14.51), CUDA 13.3, NVIDIA RTX PRO 6000 Blackwell.

**CPU-only profile** (`-DSECP256K1_BUILD_LIBBITCOIN=ON
-DSECP256K1_BUILD_LIBBITCOIN_TESTS=ON`) — builds clean, 33/33:

```
ufsecp::lbtc::gpu_available()      = false
secp256k1::gpu_columns_available() = false
PASS (CPU-only build reports no GPU)
```

`test_lbtc_direct_verify`, `test_lbtc_direct_operations` — PASS.

**GPU profile** (same + `-DSECP256K1_BUILD_LIBBITCOIN_GPU=ON
-DSECP256K1_BUILD_CUDA=ON -DSECP256K1_CUDA_ARCH_PROFILE=local-native`, minimal
GPU module set) — builds clean, 63/63:

```
ufsecp::lbtc::gpu_available()      = true
secp256k1::gpu_columns_available() = true
PASS (GPU build reports GPU present)
```

`test_lbtc_direct_verify`, `test_lbtc_direct_operations`,
`test_lbtc_direct_gpu_columns_hook` — PASS (the last one includes the new
startup assertion for `GpuColumnsAvailableHook`).

Both directions of the query are therefore exercised on real hardware: `false`
with no provider linked, `true` with the provider linked and a live device.

## Design caveat: the boolean assumes "available ⇒ faster than CPU"

The query deliberately reports no backend identity. The caller's divergence
(skip batch marshalling vs. build the batch) is justified by one assumption:
**any backend the registry reports available batch-verifies signatures much
faster than the CPU.** That holds today — CUDA, OpenCL, and Metal all have
native device kernels for the ecdsa/schnorr column verify, and the probe
requires `init()` + `is_ready()`, so "reported" means a working device.

The one way this assumption could silently fail is a registry admitting a
device that is not actually faster than the host — the realistic case being an
OpenCL CPU driver enumerated as a "GPU" platform. If that ever shows up in
practice, the fix belongs in the registry probe (exclude CPU-class devices
from `is_available`), NOT in this caller API: the boolean contract callers
branch on stays exactly as it is, and the consumer never needs to know.

## Note: pre-existing GPU-profile link failure (not from this PR)

With the **default** GPU module set, the documented GPU build command fails to
link on `dev`:

```
unresolved external symbol
  secp256k1::cuda::frost_verify_partial_batch_kernel(...)
  referenced in secp256k1::gpu::CudaBackend::frost_verify_partial_batch
```

It breaks all three `lbtc_direct*` executables. **This reproduces identically on
the unmodified parent commit (`2d6de776`)** — built from a clean worktree with
the same flags — so it is independent of this PR.

Root cause (MSVC mangles `__restrict` into the symbol name; a bare cross-TU
`extern __global__` declaration therefore references a different symbol than
the `__restrict__`-qualified kernel definition) is fixed separately on branch
`fix/cuda-kernel-restrict-mangle`. The GPU verification above used the
supported "minimal node GPU build" (`SECP256K1_GPU_BUILD_*=OFF`), which is
also the module set the vc145 NuGet package ships.
