### PR TITLE
fix: separate BIP-352 GPU audit coverage

### DIFF
--- a/audit/CMakeLists.txt
+++ b/audit/CMakeLists.txt
@@ -4586,8 +4586,10 @@ add_test(NAME regression_ct_scalar_inverse_zero
 set_tests_properties(regression_ct_scalar_inverse_zero PROPERTIES
     TIMEOUT 60 LABELS "audit;regression;ct;scalar;inverse" SKIP_RETURN_CODE 77)
 
-# GPU key-erase regression requires ufsecp_gpu symbols; only add when GPU is built.
-if(SECP256K1_BUILD_CUDA OR SECP256K1_BUILD_OPENCL OR TARGET ufsecp_gpu_host OR TARGET secp256k1_gpu_host)
+# GPU audit modules require ufsecp_gpu symbols; only enable them when the
+# concrete provider target exists (requested-but-unavailable backends do not
+# satisfy this dependency). This definition also gates BCV-5..8 below.
+if(TARGET secp256k1_gpu_host)
     target_sources(unified_audit_runner PRIVATE test_regression_gpu_key_erase_raii.cpp)
     target_compile_definitions(unified_audit_runner PRIVATE SECP256K1_BUILD_GPU_AUDIT)
 endif()
@@ -5079,16 +5081,29 @@ endif()
 add_executable(test_regression_bip352_ct_varbase_standalone
     test_regression_bip352_ct_varbase.cpp)
 audit_target_defaults(test_regression_bip352_ct_varbase_standalone)
-if(TARGET secp256k1_gpu_host)
-    target_link_libraries(test_regression_bip352_ct_varbase_standalone PRIVATE secp256k1_gpu_host)
-    target_include_directories(test_regression_bip352_ct_varbase_standalone PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/../src/gpu/include)
-endif()
-target_compile_definitions(test_regression_bip352_ct_varbase_standalone PRIVATE STANDALONE_TEST)
 add_test(NAME regression_bip352_ct_varbase COMMAND test_regression_bip352_ct_varbase_standalone)
 set_tests_properties(regression_bip352_ct_varbase PROPERTIES TIMEOUT 120
     SKIP_RETURN_CODE 77
     LABELS "audit;ct_analysis;bip352;regression")
+
+# BCV-5..8 require the real GPU C ABI provider. Keep them in a distinct
+# target so the always-built BCV-1..4 CPU regression has no GPU dependency.
+if(TARGET secp256k1_gpu_host)
+    add_executable(test_regression_bip352_ct_varbase_gpu_standalone
+        test_regression_bip352_ct_varbase.cpp)
+    audit_target_defaults(test_regression_bip352_ct_varbase_gpu_standalone)
+    target_link_libraries(test_regression_bip352_ct_varbase_gpu_standalone PRIVATE
+        secp256k1_gpu_host)
+    target_include_directories(test_regression_bip352_ct_varbase_gpu_standalone PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/gpu/include)
+    target_compile_definitions(test_regression_bip352_ct_varbase_gpu_standalone PRIVATE
+        SECP256K1_BUILD_GPU_AUDIT)
+    add_test(NAME regression_bip352_ct_varbase_gpu
+        COMMAND test_regression_bip352_ct_varbase_gpu_standalone)
+    set_tests_properties(regression_bip352_ct_varbase_gpu PROPERTIES TIMEOUT 120
+        SKIP_RETURN_CODE 77
+        LABELS "audit;ct_analysis;bip352;gpu;regression")
+endif()
 
 # Regression: point_add_mixed_complete FE52 magnitude contract (May 2026)
 # Detects: normalize_weak X1/Y1 fix must stay in place; tests mixed-add

--- a/audit/CMakeLists.txt
+++ b/audit/CMakeLists.txt
@@ -5097,7 +5097,7 @@ if(TARGET secp256k1_gpu_host)
     target_include_directories(test_regression_bip352_ct_varbase_gpu_standalone PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/gpu/include)
     target_compile_definitions(test_regression_bip352_ct_varbase_gpu_standalone PRIVATE
-        SECP256K1_BUILD_GPU_AUDIT)
+        SECP256K1_BUILD_GPU_AUDIT STANDALONE_TEST)
     add_test(NAME regression_bip352_ct_varbase_gpu
         COMMAND test_regression_bip352_ct_varbase_gpu_standalone)
     set_tests_properties(regression_bip352_ct_varbase_gpu PROPERTIES TIMEOUT 120

--- a/audit/test_regression_bip352_ct_varbase.cpp
+++ b/audit/test_regression_bip352_ct_varbase.cpp
@@ -49,7 +49,9 @@
 #endif
 
 #include "ufsecp256k1.h"
+#if defined(SECP256K1_BUILD_GPU_AUDIT)
 #include "ufsecp/ufsecp_gpu.h"
+#endif
 
 #include <cstring>
 #include <cstdio>
@@ -106,6 +108,10 @@ static void test_bcv_cpu_correctness() {
 /* BCV-5..8: independent CPU-oracle byte-exact equality, limb-boundary keys */
 /* ----------------------------------------------------------------------- */
 
+#if defined(SECP256K1_BUILD_GPU_AUDIT)
+
+static bool g_gpu_advisory_skip = false;
+
 // Deterministic (not cryptographically random) byte fill -- reproducible
 // across runs/machines, matching the pattern used elsewhere in this audit
 // suite (e.g. audit/test_gpu_bip352_scan.cpp's fill_det).
@@ -153,18 +159,34 @@ static void test_bcv_gpu_batch_matches_cpu_oracle() {
     uint32_t cnt = ufsecp_gpu_backend_count(ids, 8);
     if (cnt == 0) {
         std::printf("SKIP BCV-5..8: no GPU backend available (advisory)\n");
+        g_gpu_advisory_skip = true;
         return;
     }
+
+    uint32_t backend_id = UFSECP_GPU_BACKEND_NONE;
+    for (uint32_t i = 0; i < cnt && i < 8; ++i) {
+        if (ufsecp_gpu_is_available(ids[i])) {
+            backend_id = ids[i];
+            break;
+        }
+    }
+    if (backend_id == UFSECP_GPU_BACKEND_NONE) {
+        std::printf("SKIP BCV-5..8: no GPU device available (advisory)\n");
+        g_gpu_advisory_skip = true;
+        return;
+    }
+
     ufsecp_gpu_ctx* gctx = nullptr;
-    ufsecp_error_t grc = ufsecp_gpu_ctx_create(&gctx, ids[0], 0);
+    ufsecp_error_t grc = ufsecp_gpu_ctx_create(&gctx, backend_id, 0);
+    ASSERT_TRUE(grc == UFSECP_OK && gctx, "BCV-5: GPU ctx creation must succeed for an available device");
     if (grc != UFSECP_OK || !gctx) {
-        std::printf("SKIP BCV-5: GPU ctx creation failed (advisory)\n");
         return;
     }
 
     ufsecp_ctx* ctx = nullptr;
-    if (ufsecp_ctx_create(&ctx) != UFSECP_OK || !ctx) {
-        std::printf("SKIP BCV-5: CPU ctx creation failed (advisory)\n");
+    ufsecp_error_t crc = ufsecp_ctx_create(&ctx);
+    ASSERT_TRUE(crc == UFSECP_OK && ctx, "BCV-5: CPU oracle ctx creation must succeed");
+    if (crc != UFSECP_OK || !ctx) {
         ufsecp_gpu_ctx_destroy(gctx);
         return;
     }
@@ -245,6 +267,7 @@ static void test_bcv_gpu_batch_matches_cpu_oracle() {
     const int spend_counts[] = {1, 2, 3, MAX_SPEND};
     int cells_checked = 0;
     bool any_supported = false;
+    bool all_unsupported = true;
     for (const auto& sk_case : scan_keys) {
         uint8_t scan_pubkey33[33] = {};
         if (ufsecp_pubkey_create(ctx, sk_case.sk, scan_pubkey33) != UFSECP_OK) {
@@ -257,6 +280,7 @@ static void test_bcv_gpu_batch_matches_cpu_oracle() {
                 gctx, sk_case.sk, &spend_pk[0][0], static_cast<size_t>(n_spend),
                 tweak_pk, MAX_TWEAKS, matrix.data());
             if (rc == UFSECP_ERR_GPU_UNSUPPORTED) continue; // backend doesn't implement this op
+            all_unsupported = false;
             ASSERT_TRUE(rc == UFSECP_OK, "BCV-6: GPU multispend scan must return UFSECP_OK");
             if (rc != UFSECP_OK) continue;
             any_supported = true;
@@ -296,20 +320,29 @@ static void test_bcv_gpu_batch_matches_cpu_oracle() {
                     "oracle cells checked\n",
                     static_cast<int>(scan_keys.size()), cells_checked);
         ASSERT_TRUE(cells_checked > 0, "BCV-6b: at least one oracle cell must have been checked");
-    } else {
+    } else if (all_unsupported) {
         std::printf("SKIP BCV-5..8: bip352_scan_batch_multispend unsupported on every "
                     "available GPU backend (advisory)\n");
+        g_gpu_advisory_skip = true;
     }
 
     ufsecp_ctx_destroy(ctx);
     ufsecp_gpu_ctx_destroy(gctx);
 }
+#endif
 
 int test_regression_bip352_ct_varbase_run() {
     g_fail = 0;
     test_bcv_cpu_correctness();
+#if defined(SECP256K1_BUILD_GPU_AUDIT)
+    g_gpu_advisory_skip = false;
     test_bcv_gpu_batch_matches_cpu_oracle();
+#endif
 
+#if defined(SECP256K1_BUILD_GPU_AUDIT) && defined(STANDALONE_TEST)
+    if (g_fail == 0 && g_gpu_advisory_skip)
+        return 77;
+#endif
     if (g_fail == 0)
         std::printf("PASS: BIP-352 CT variable-base scalar mul regression (CRIT-02)\n");
     return g_fail;

--- a/audit/test_regression_bip352_ct_varbase.cpp
+++ b/audit/test_regression_bip352_ct_varbase.cpp
@@ -45,7 +45,9 @@
 
 #ifndef UNIFIED_AUDIT_RUNNER
 #include <cstdio>
+#ifndef STANDALONE_TEST
 #define STANDALONE_TEST
+#endif
 #endif
 
 #include "ufsecp256k1.h"


### PR DESCRIPTION
## Summary

Separate the BIP-352 variable-base regression into independent CPU and
GPU audit targets.

The existing standalone regression always compiled GPU C-ABI calls, but
linked a GPU provider only when a concrete accelerator target existed.
CPU-only builds could therefore fail with unresolved `ufsecp_gpu_*`
references.

This change:

* keeps BCV-1 through BCV-4 in the unconditional CPU target;
* moves BCV-5 through BCV-8 into a provider-gated GPU target;
* gates GPU headers and code on `SECP256K1_BUILD_GPU_AUDIT`;
* enables GPU audit sources only when `secp256k1_gpu_host` exists;
* reports genuinely unavailable or unsupported GPU coverage as CTest
  skip 77;
* retains failures for provider context and operational execution errors.

No field formulas, reduction constants, public APIs, or point/scalar
algorithms are changed.

## Validation

CPU-only:

* Clang 21.1.8 Release: passed
* Clang 21.1.8 Debug: passed
* MSVC 19.50 Release: passed
* confirmed the CPU regression has no `ufsecp_gpu_*` references;
* confirmed it does not link `secp256k1_gpu_host`;
* confirmed the GPU regression target is absent without a concrete
  provider.

OpenCL:

* configured and built the real OpenCL provider on an NVIDIA GeForce
  RTX 4070;
* compiled and linked the dedicated GPU regression target;
* confirmed CTest registration and real provider execution;
* execution retains the existing independent BCV-6 kernel-initialization
  failure rather than converting it into a skip.

## Known limitations

* The OpenCL GPU regression reaches the real provider but does not pass
  because of the pre-existing BCV-6 kernel-initialization failure.
* CUDA and Metal were not available for local validation.
* The Windows OpenCL build required the existing explicit OpenCL-header
  include workaround.
* Validation was focused on the affected targets rather than the full
  repository test suite.