### PR TITLE
fix(fe26): align fe26 mul/sqr O2 marker with the fe52 inlining policy (clang -Wunknown-attributes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   generation with `ufsecp_last_error()` / `ufsecp_last_error_msg()` diagnostics.
   The existing stateless `ufsecp_addr_p2sh` symbol remains available and
   produces byte-identical addresses.
+- Completed the clang `-Wunknown-attributes` cleanup for the field kernels:
+  the two `fe26` inner functions (`fe26_mul_inner` / `fe26_sqr_inner`) still
+  spelled the GCC-only `optimize("O2")` attribute under a `__GNUC__ ||
+  __clang__` guard. They now follow the same policy as the `fe52` kernels
+  (see the "Field-kernel inlining policy" block in `field_52_impl.hpp`):
+  `optimize("O2") + noinline` on GCC, plain `noinline` on clang, which drops
+  the remaining two spurious warnings per translation unit on clang builds.
 
 ### Credited
 

--- a/src/cpu/include/secp256k1/field_26.hpp
+++ b/src/cpu/include/secp256k1/field_26.hpp
@@ -127,11 +127,12 @@ struct alignas(4) FieldElement26 {
 // fe26 op is 20-40ns — inlining removes it (P0 from perf report).
 //
 // fe26_mul_inner / fe26_sqr_inner are declared without SECP256K1_INLINE
-// because their definitions in field_26.cpp explicitly mark them
-// `__attribute__((optimize("O2"), noinline))` on GCC/Clang to keep these
-// large bodies out of the caller's inlining budget. SECP256K1_INLINE
-// expands to `__attribute__((always_inline)) inline` on GCC/Clang and
-// would conflict with the noinline attribute (-Werror=attributes).
+// because their definitions in field_26.cpp explicitly mark them noinline per
+// the field-kernel inlining policy: optimize("O2") + noinline on GCC, clang
+// gets plain noinline since it ignores the GCC-only optimize attribute (see
+// the "Field-kernel inlining policy" block in field_52_impl.hpp).
+// SECP256K1_INLINE expands to `__attribute__((always_inline)) inline` on
+// GCC/Clang and would conflict with the noinline attribute (-Werror=attributes).
 void fe26_mul_inner(std::uint32_t* SECP256K1_RESTRICT r,
                     const std::uint32_t* SECP256K1_RESTRICT a,
                     const std::uint32_t* SECP256K1_RESTRICT b) noexcept;

--- a/src/cpu/src/field_26.cpp
+++ b/src/cpu/src/field_26.cpp
@@ -311,10 +311,14 @@ void FieldElement26::negate_assign(unsigned magnitude) noexcept {
 //   c: max ~10 products x 2^52 + u_k*R0 (2^40) ~= 2^55.3, fits uint64_t
 //   u_k: extracted 26-bit value, so u_k*R0 <= 2^40, u_k*R1 <= 2^36
 
-// Same noinline + optimize("O2") guard as fe52_mul_inner — see field_52_impl.hpp.
+// Same per-function O2 policy as fe52_mul_inner — see the "Field-kernel
+// inlining policy" block in field_52_impl.hpp. optimize("O2") is GCC-only;
+// clang ignores it (-Wunknown-attributes) and gets plain noinline here.
 // Cannot use `static` here because the function is declared in field_26.hpp.
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__)
 __attribute__((optimize("O2"), noinline))
+#elif defined(__clang__)
+__attribute__((noinline))
 #else
 SECP256K1_INLINE
 #endif
@@ -496,9 +500,13 @@ void fe26_mul_inner(std::uint32_t* SECP256K1_RESTRICT r,
 // Same two-accumulator algorithm as mul, but using a[i]*a[j]=a[j]*a[i]
 // symmetry: 2*a[i]*a[j] for i!=j, a[i]^2 for i=j.
 
-// Same noinline + optimize("O2") guard as fe52_sqr_inner — see field_52_impl.hpp.
-#if defined(__GNUC__) || defined(__clang__)
+// Same per-function O2 policy as fe52_sqr_inner — see the "Field-kernel
+// inlining policy" block in field_52_impl.hpp (GCC-only optimize; clang gets
+// plain noinline).
+#if defined(__GNUC__) && !defined(__clang__)
 __attribute__((optimize("O2"), noinline))
+#elif defined(__clang__)
+__attribute__((noinline))
 #else
 SECP256K1_INLINE
 #endif


### PR DESCRIPTION
Rebased on current dev. The fe52 kernels already carry the field-kernel inlining policy (GCC-only `optimize("O2")` + noinline; clang gets plain noinline). The two **fe26** inner kernels were left on the old `__GNUC__ || __clang__` guard, so clang builds still emit two `-Wunknown-attributes` warnings per translation unit.

## Change

- `fe26_mul_inner` / `fe26_sqr_inner` now use the same policy as `fe52_mul_inner` / `fe52_sqr_inner`: `optimize("O2") + noinline` on GCC (byte-identical attribute string), plain `noinline` on clang.
- Comments updated to reference the "Field-kernel inlining policy" block in `field_52_impl.hpp`; the `field_26.hpp` note no longer claims the attribute applies "on GCC/Clang".
- CHANGELOG entry under `[Unreleased]`.

## Verification

- Apple clang 17: `-fsyntax-only` of `field_26.cpp` is warning-free after the change.
- GCC branch is byte-for-byte identical to the previous attribute, so codegen/behavior is unchanged.
- This is the residual half of the original PR #407 (the fe52 half is already on dev).