### PR TITLE
fix(gpu): enforce strict r/s<n compact-ECDSA range on every GPU verify path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   documented "collect verdict is bit-identical to verify_batch" invariant. Each
   backend's `ecdsa_verify` now rejects `r >= n` or `s >= n` up front (single
   choke point shared by single/batch/collect and sign-and-verify), and a
-  regression audit (`test_regression_gpu_ecdsa_compact_range.cpp`) pins it with
+  regression audit (`test_gpu_ecdsa_compact_range.cpp`) pins it with
   an always-run CPU source gate (failed against the pre-fix sources) plus an
   on-device `{0, n-1, n, 2^256-1, s+n}` boundary-scalar differential that
   self-skips without a GPU.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   carry loss in `fe26` (the production field on ARM64 and 32-bit targets)
   is caught by this module before any downstream module. Registered in the
   unified audit runner under `math_invariants`.
+- Enforced a uniform strict compact-ECDSA scalar contract on every GPU verify
+  path. Previously the device-side `ecdsa_verify()` in the CUDA, Metal and
+  OpenCL backends only rejected zero scalars and silently reduced any `r`/`s`
+  limb value `>= n` modulo the group order: the CUDA `ecdsa_verify_collect`
+  kernel and the Metal `ecdsa_verify_batch_compressed` / `lbtc_ecdsa_verify_collect`
+  shaders therefore accepted the `s+n` congruent-malleation encoding that the
+  CUDA batch kernel, OpenCL and the CPU strict parse all reject — violating the
+  documented "collect verdict is bit-identical to verify_batch" invariant. Each
+  backend's `ecdsa_verify` now rejects `r >= n` or `s >= n` up front (single
+  choke point shared by single/batch/collect and sign-and-verify), and a
+  regression audit (`test_regression_gpu_ecdsa_compact_range.cpp`) pins it with
+  an always-run CPU source gate (failed against the pre-fix sources) plus an
+  on-device `{0, n-1, n, 2^256-1, s+n}` boundary-scalar differential that
+  self-skips without a GPU.
 
 ### Credited
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Project-wide (branch-independent — not pinned to `main` or `dev`):
 
 > **No external third-party security audit has been performed.** All audit evidence is self-generated and independently reproducible via CAAS. See [SECURITY.md](SECURITY.md) §Audit Status.
 
-> **Audit methodology:** CAAS (Continuous Automated Assurance System) — a multi-layer automated audit framework: LLVM ct-verif, Valgrind taint analysis, dudect statistical timing, 475-module unified runner with 276 exploit PoC tests.
+> **Audit methodology:** CAAS (Continuous Automated Assurance System) — a multi-layer automated audit framework: LLVM ct-verif, Valgrind taint analysis, dudect statistical timing, 476-module unified runner with 276 exploit PoC tests.
 
 **Reproduce from patch (primary — stable):**
 ```bash
@@ -274,7 +274,7 @@ This project: `code → test → execution → evidence → continuous verificat
 We do not rely on trust. We provide reproducible evidence.
 
 - Every exploit attempt becomes a permanent regression test
-- Every commit runs ≈600K explicitly itemized field/scalar/point/CT assertions (plus full-suite KAT/differential/fuzz checks, not individually counted) across 199 non-exploit audit modules and 276 exploit PoCs ( 475 modules total; count via `python3 ci/sync_module_count.py`; canonical data: `docs/canonical_data.json`)
+- Every commit runs ≈600K explicitly itemized field/scalar/point/CT assertions (plus full-suite KAT/differential/fuzz checks, not individually counted) across 200 non-exploit audit modules and 276 exploit PoCs ( 476 modules total; count via `python3 ci/sync_module_count.py`; canonical data: `docs/canonical_data.json`)
 - Every claim maps to a test in [docs/AUDIT_TRACEABILITY.md](docs/AUDIT_TRACEABILITY.md)
 - Every performance number has pinned compiler/driver/toolkit versions and raw logs
 
@@ -1624,7 +1624,7 @@ cosign verify-blob SHA256SUMS \
 | [GPU Validation Matrix](docs/GPU_VALIDATION_MATRIX.md) | Per-backend op coverage and validation status |
 | [Feature Maturity](docs/FEATURE_MATURITY.md) | Per-feature GPU/CT/fuzz/tier status table |
 | [Supported Guarantees](include/ufsecp/SUPPORTED_GUARANTEES.md) | ABI stability tiers and commitment levels |
-| [Audit Coverage](docs/AUDIT_COVERAGE.md) | Full audit report with 199 non-exploit modules + 276 exploit PoCs and platform verdicts |
+| [Audit Coverage](docs/AUDIT_COVERAGE.md) | Full audit report with 200 non-exploit modules + 276 exploit PoCs and platform verdicts |
 | [Audit Guide](docs/AUDIT_GUIDE.md) | How to run and interpret audit suite |
 | [Test Matrix](docs/TEST_MATRIX.md) | Comprehensive test coverage map for auditors |
 | [ARM64 Audit & Benchmark](docs/ARM64_AUDIT_BENCHMARK.md) | ARM64 platform certification and performance analysis |

--- a/audit/CMakeLists.txt
+++ b/audit/CMakeLists.txt
@@ -471,7 +471,7 @@ if(TARGET secp256k1_gpu_host AND (TARGET ufsecp_shared OR TARGET ufsecp_static))
     # CPU-only source gate always runs (needs UFSECP_SOURCE_ROOT to resolve the
     # in-tree kernel sources); the on-device boundary-scalar differential
     # self-skips when no GPU backend is available.
-    add_executable(test_gpu_ecdsa_compact_range test_regression_gpu_ecdsa_compact_range.cpp)
+    add_executable(test_gpu_ecdsa_compact_range test_gpu_ecdsa_compact_range.cpp)
     target_link_libraries(test_gpu_ecdsa_compact_range PRIVATE ${UFSECP_GPU_TEST_LIB})
     target_include_directories(test_gpu_ecdsa_compact_range PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
@@ -4086,7 +4086,7 @@ add_executable(unified_audit_runner
     # Native GPU collect verdict == verify_batch verdict per-row (null-ctx contract runs CPU-only)
     test_gpu_collect_verify_parity.cpp
     # GPU ECDSA compact-sig strict r/s<n range: CPU source gate + on-device boundary-scalar differential
-    test_regression_gpu_ecdsa_compact_range.cpp
+    test_gpu_ecdsa_compact_range.cpp
     # CPU range-proof → GPU Bulletproof poly-check consistency (advisory; skips w/o GPU/ZK)
     test_gpu_zk_prove_verify_differential.cpp
     # -- field representation tests --

--- a/audit/CMakeLists.txt
+++ b/audit/CMakeLists.txt
@@ -467,6 +467,26 @@ if(TARGET secp256k1_gpu_host AND (TARGET ufsecp_shared OR TARGET ufsecp_static))
         TIMEOUT 120
         LABELS "gpu;libbitcoin;collect;differential")
 
+    # -- GPU ECDSA compact-sig strict-range regression ----------------------
+    # CPU-only source gate always runs (needs UFSECP_SOURCE_ROOT to resolve the
+    # in-tree kernel sources); the on-device boundary-scalar differential
+    # self-skips when no GPU backend is available.
+    add_executable(test_gpu_ecdsa_compact_range test_regression_gpu_ecdsa_compact_range.cpp)
+    target_link_libraries(test_gpu_ecdsa_compact_range PRIVATE ${UFSECP_GPU_TEST_LIB})
+    target_include_directories(test_gpu_ecdsa_compact_range PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/../include
+        ${CMAKE_BINARY_DIR}/include/ufsecp
+    )
+    target_compile_definitions(test_gpu_ecdsa_compact_range PRIVATE
+        STANDALONE_TEST
+        UFSECP_SOURCE_ROOT="${CMAKE_CURRENT_SOURCE_DIR}/.."
+    )
+    add_test(NAME gpu_ecdsa_compact_range COMMAND test_gpu_ecdsa_compact_range)
+    set_tests_properties(gpu_ecdsa_compact_range PROPERTIES
+        TIMEOUT 120
+        LABELS "gpu;ecdsa;range;differential;regression")
+
     # -- GPU ops equivalence (GPU vs CPU reference) --
     add_executable(test_gpu_ops_equivalence test_gpu_ops_equivalence.cpp)
     target_link_libraries(test_gpu_ops_equivalence PRIVATE ${UFSECP_GPU_TEST_LIB})
@@ -550,6 +570,7 @@ if(TARGET secp256k1_gpu_host AND (TARGET ufsecp_shared OR TARGET ufsecp_static))
             test_gpu_ecdsa_snark_witness test_gpu_bip352_scan
             test_gpu_zk_prove_verify_differential
             test_gpu_collect_verify_parity
+            test_gpu_ecdsa_compact_range
             PROPERTIES INTERPROCEDURAL_OPTIMIZATION FALSE
         )
     endif()
@@ -4064,6 +4085,8 @@ add_executable(unified_audit_runner
     test_gpu_lbtc_columns_diff.cpp
     # Native GPU collect verdict == verify_batch verdict per-row (null-ctx contract runs CPU-only)
     test_gpu_collect_verify_parity.cpp
+    # GPU ECDSA compact-sig strict r/s<n range: CPU source gate + on-device boundary-scalar differential
+    test_regression_gpu_ecdsa_compact_range.cpp
     # CPU range-proof → GPU Bulletproof poly-check consistency (advisory; skips w/o GPU/ZK)
     test_gpu_zk_prove_verify_differential.cpp
     # -- field representation tests --

--- a/audit/test_gpu_ecdsa_compact_range.cpp
+++ b/audit/test_gpu_ecdsa_compact_range.cpp
@@ -30,15 +30,22 @@
  * compact contract across CPU, CUDA, OpenCL and Metal.
  *
  * This module pins the fix two ways:
- *   [A] CPU-only SOURCE GATE (always runs, every runner): scans the in-tree
- *       kernel sources and asserts the strict range guard is present in each
- *       backend's ecdsa_verify() and that the CUDA batch kernel keeps its
- *       strict parse. This FAILED against the pre-fix sources, so it is the
- *       real always-bit-rot regression gate.
+ *   [A] CPU-only SOURCE GATE (always runs, every runner): locates each
+ *       backend's ecdsa_verify() / ecdsa_verify_impl() function definition,
+ *       brace-matches its body and asserts the strict r/s >= n guard appears
+ *       INSIDE that body, before the scalar_inverse() call. A guard stranded
+ *       in a helper no verify path calls no longer satisfies the gate. This
+ *       FAILED against the pre-fix sources, so it is the real always-bit-rot
+ *       regression gate.
  *   [B] On-device BOUNDARY-SCALAR differential (advisory; self-skips when no
- *       GPU backend is available): feeds r/s on the {0, n-1, n, 2^256-1,
- *       s+n-congruent class} boundaries through BOTH the batch and collect
- *       entrypoints and asserts per-row uniformity with the CPU strict oracle.
+ *       GPU backend is available): builds a valid base signature with a SMALL
+ *       r and SMALL s (r = 1, s = 0x0307) via ufsecp_ecdsa_recover, so every
+ *       congruent malleation -- (r, s+n), (r+n, s), (r+n, s+n) -- is
+ *       32-byte-representable and the collect-vs-batch divergence is actually
+ *       exercisable on hardware. Rows are fed through BOTH the batch and
+ *       collect entrypoints and asserted uniform per-row against the CPU strict
+ *       oracle; the base row must pass both (a guard that rejects everything
+ *       would fail here too).
  *
  * PUBLIC-DATA inputs only; verify is variable-time by design. No GPU needed to
  * build/run the source gate; the on-device part self-skips cleanly (operational
@@ -112,24 +119,79 @@ void copy32(const uint8_t src[32], uint8_t dst[32]) { std::memcpy(dst, src, 32);
 
 // ---------------------------------------------------------------------------
 // [A] CPU-only source gate -- runs on EVERY runner, no GPU required. Each
-//     backend's device ecdsa_verify() must carry the strict >= n guard; the
-//     CUDA batch kernel must keep its strict compact parse. These CHECKs fail
-//     against the pre-fix sources, so this section trees the regression even
+//     backend's device ecdsa_verify() must carry the strict >= n guard, scoped
+//     to the actual function body and ordered before the scalar_inverse() call;
+//     the CUDA batch kernel must keep its strict compact parse. These CHECKs
+//     fail against the pre-fix sources (and against a guard stranded in a
+//     helper no verify path calls), so this section trees the regression even
 //     on CPU-only CI (no GPU ever exercised it).
 // ---------------------------------------------------------------------------
+
+// Extract the body of a function whose signature starts at sig_pos: from the
+// opening brace to the matching close, skipping strings, line and block
+// comments. Empty string on any failure (which the CHECKs then flag).
+std::string extract_function_body(const std::string& src, size_t sig_pos) {
+    const size_t n = src.size();
+    const size_t brace = src.find('{', sig_pos);
+    if (brace == std::string::npos) return {};
+    int depth = 0;
+    bool in_str = false, in_line = false, in_block = false;
+    for (size_t i = brace; i < n; ++i) {
+        const char c = src[i];
+        if (in_line) {
+            if (c == '\n') in_line = false;
+            continue;
+        }
+        if (in_block) {
+            if (c == '*' && i + 1 < n && src[i + 1] == '/') { in_block = false; ++i; }
+            continue;
+        }
+        if (in_str) {
+            if (c == '\\') { ++i; continue; }
+            if (c == '"') in_str = false;
+            continue;
+        }
+        if (c == '/' && i + 1 < n) {
+            if (src[i + 1] == '/') { in_line = true; ++i; continue; }
+            if (src[i + 1] == '*') { in_block = true; ++i; continue; }
+        }
+        if (c == '"') { in_str = true; continue; }
+        if (c == '{') { ++depth; continue; }
+        if (c == '}') {
+            --depth;
+            if (depth == 0) return src.substr(brace + 1, i - brace - 1);
+        }
+    }
+    return {};
+}
+
+// True when guard appears in body before the scalar_inverse() call
+// ("scalar_inverse" also matches scalar_inverse_impl in the OpenCL kernel).
+bool guard_before_inverse(const std::string& body, const std::string& guard) {
+    const size_t g = body.find(guard);
+    if (g == std::string::npos) return false;
+    const size_t inv = body.find("scalar_inverse");
+    return inv != std::string::npos && g < inv;
+}
+
 void test_source_gate() {
     AUDIT_LOG("[gpu_ecdsa_compact_range] source gate (CPU-only, always runs)\n");
 
-    // -- CUDA: device ecdsa_verify() reject r/s >= n (ecdsa.cuh), and the
-    //    batch kernel keeps the strict compact parse (secp256k1.cu). ------
+    // -- CUDA: strict guard inside ecdsa_verify(), before scalar_inverse(),
+    //    and the batch kernel keeps its strict compact parse. ------------
     {
         std::string cuh = audit_read_source_file("src/cuda/include/ecdsa.cuh");
         CHECK(!cuh.empty(), "src/cuda/include/ecdsa.cuh must be readable (in-tree source)");
         if (!cuh.empty()) {
-            CHECK(cuh.find("scalar_ge(&sig->r, ORDER)") != std::string::npos,
-                  "[A] CUDA ecdsa_verify rejects r >= n (scalar_ge guard)");
-            CHECK(cuh.find("scalar_ge(&sig->s, ORDER)") != std::string::npos,
-                  "[A] CUDA ecdsa_verify rejects s >= n (scalar_ge guard)");
+            const size_t sig = cuh.find("bool ecdsa_verify(");
+            const std::string body = extract_function_body(cuh, sig);
+            CHECK(!body.empty(), "[A] CUDA ecdsa_verify( definition found and brace-matched");
+            if (!body.empty()) {
+                CHECK(guard_before_inverse(body, "scalar_ge(&sig->r, ORDER)"),
+                      "[A] CUDA ecdsa_verify rejects r >= n inside its body, before scalar_inverse");
+                CHECK(guard_before_inverse(body, "scalar_ge(&sig->s, ORDER)"),
+                      "[A] CUDA ecdsa_verify rejects s >= n inside its body, before scalar_inverse");
+            }
         }
         std::string cu = audit_read_source_file("src/cuda/src/secp256k1.cu");
         CHECK(!cu.empty(), "src/cuda/src/secp256k1.cu must be readable (in-tree source)");
@@ -139,60 +201,79 @@ void test_source_gate() {
         }
     }
 
-    // -- Metal: ecdsa_verify() reject r/s >= n (secp256k1_extended.h) via the
-    //    scalar256_ge_n() helper that compares limbs against SECP256K1_N. --
+    // -- Metal: guard inside the 3-arg ecdsa_verify( overload -- the choke
+    //    point the 4-arg overload and both batch/collect kernels delegate to --
+    //    comparing sig.r/sig.s against the order built from SECP256K1_N. ---
     {
         std::string mh = audit_read_source_file("src/metal/shaders/secp256k1_extended.h");
         CHECK(!mh.empty(), "src/metal/shaders/secp256k1_extended.h must be readable (in-tree source)");
         if (!mh.empty()) {
-            CHECK(mh.find("inline bool scalar256_ge_n") != std::string::npos,
-                  "[A] Metal defines scalar256_ge_n() range helper");
-            CHECK(mh.find("scalar256_ge_n(sig.r)") != std::string::npos,
-                  "[A] Metal ecdsa_verify rejects r >= n (scalar256_ge_n guard)");
-            CHECK(mh.find("scalar256_ge_n(sig.s)") != std::string::npos,
-                  "[A] Metal ecdsa_verify rejects s >= n (scalar256_ge_n guard)");
+            const size_t sig = mh.find("bool ecdsa_verify(thread const uchar");
+            const std::string body = extract_function_body(mh, sig);
+            CHECK(!body.empty(), "[A] Metal ecdsa_verify( 3-arg definition found and brace-matched");
+            if (!body.empty()) {
+                CHECK(guard_before_inverse(body, "scalar256_ge(sig.r, order_n)"),
+                      "[A] Metal ecdsa_verify rejects r >= n inside its body, before scalar_inverse");
+                CHECK(guard_before_inverse(body, "scalar256_ge(sig.s, order_n)"),
+                      "[A] Metal ecdsa_verify rejects s >= n inside its body, before scalar_inverse");
+            }
         }
     }
 
-    // -- OpenCL: ecdsa_verify_impl() reject r/s >= n (secp256k1_extended.cl)
-    //    using the same lbtc_scalar_ge_order() primitive the strict compact
-    //    parser already uses. ----------------------------------------------
+    // -- OpenCL: guard inside ecdsa_verify_impl(), before
+    //    scalar_inverse_impl(). Defense in depth (OpenCL parsers were already
+    //    strict) but the choke point must still carry it. -----------------
     {
         std::string cl = audit_read_source_file("src/opencl/kernels/secp256k1_extended.cl");
         CHECK(!cl.empty(), "src/opencl/kernels/secp256k1_extended.cl must be readable (in-tree source)");
         if (!cl.empty()) {
-            CHECK(cl.find("lbtc_scalar_ge_order(&sig->r)") != std::string::npos,
-                  "[A] OpenCL ecdsa_verify_impl rejects r >= n (lbtc_scalar_ge_order guard)");
-            CHECK(cl.find("lbtc_scalar_ge_order(&sig->s)") != std::string::npos,
-                  "[A] OpenCL ecdsa_verify_impl rejects s >= n (lbtc_scalar_ge_order guard)");
+            const size_t sig = cl.find("int ecdsa_verify_impl(");
+            const std::string body = extract_function_body(cl, sig);
+            CHECK(!body.empty(), "[A] OpenCL ecdsa_verify_impl( definition found and brace-matched");
+            if (!body.empty()) {
+                CHECK(guard_before_inverse(body, "lbtc_scalar_ge_order(&sig->r)"),
+                      "[A] OpenCL ecdsa_verify_impl rejects r >= n inside its body, before scalar_inverse");
+                CHECK(guard_before_inverse(body, "lbtc_scalar_ge_order(&sig->s)"),
+                      "[A] OpenCL ecdsa_verify_impl rejects s >= n inside its body, before scalar_inverse");
+            }
         }
     }
 }
 
 // ---------------------------------------------------------------------------
 // [B] On-device boundary-scalar differential (advisory; self-skips w/o GPU).
-//     Builds one valid compressed compact row plus a family of boundary
-//     encodings and asserts the batch/collect per-row verdicts are uniform with
-//     the CPU strict oracle (ufsecp_ecdsa_verify: parse_compact_strict + low-S).
+//     Builds one valid compact row whose r and s are SMALL (r = 1, s = 0x0307)
+//     by signing-recovering the matching public key, so every congruent
+//     malleation (r, s+n), (r+n, s), (r+n, s+n) fits in 32 bytes and actually
+//     reaches the device. Verdicts are asserted uniform with the CPU strict
+//     oracle (ufsecp_ecdsa_verify: parse_compact_strict + low-S).
 // ---------------------------------------------------------------------------
 struct Row {
     const char* label;
     bool       want_valid;   // expected per the CPU strict oracle
 };
 
-// Deterministically produce a LOW-S compact signature accepted by the CPU
-// strict oracle. Returns false if signing/verification infra is unavailable.
-bool make_valid_row(ufsecp_ctx* sc, uint8_t msg[32], uint8_t pub33[33],
-                    uint8_t sig64[64]) {
-    for (int seed = 0; seed < 32; ++seed) {
-        uint8_t sk[32] = {0};
-        sk[31] = (uint8_t)(seed * 7 + 3);
-        sk[30] = (uint8_t)(seed * 13 + 1);
-        for (int j = 0; j < 32; ++j)
-            msg[j] = (uint8_t)(seed * 29 + j * 11 + 5);
-        if (ufsecp_pubkey_create(sc, sk, pub33) != UFSECP_OK) return false;
-        if (ufsecp_ecdsa_sign(sc, msg, sk, sig64) != UFSECP_OK) continue;
-        if (ufsecp_ecdsa_verify(sc, msg, sig64, pub33) == UFSECP_OK) return true;
+// Sign-recover the pubkey for a hand-built small-(r, s) signature.
+//   r[31] = r_small, s[62] = 0x03, s[63] = 0x07  ->  r = small, s = 0x0307.
+// A canonical low-S ufsecp_ecdsa_sign output (s ~ 2^255) would make s+n
+// unrepresentable in 32 bytes; a small s makes the malleation class reachable.
+// Returns false only if 32 candidates fail to recover (infrastructure issue).
+bool make_small_valid_row(ufsecp_ctx* sc, uint8_t msg[32], uint8_t pub33[33],
+                          uint8_t sig64[64]) {
+    for (int j = 0; j < 32; ++j)
+        msg[j] = (uint8_t)(0xa5 + j * 7);
+    uint8_t sig[64];
+    for (uint8_t r_small = 1; r_small < 32; ++r_small) {
+        std::memset(sig, 0, 64);
+        sig[31] = r_small;                       // r = r_small
+        sig[62] = 0x03; sig[63] = 0x07;          // s = 0x0307 (tiny, low-S)
+        for (int recid = 0; recid < 2; ++recid) {
+            if (ufsecp_ecdsa_recover(sc, msg, sig, recid, pub33) != UFSECP_OK) continue;
+            if (ufsecp_ecdsa_verify(sc, msg, sig, pub33) == UFSECP_OK) {
+                std::memcpy(sig64, sig, 64);
+                return true;
+            }
+        }
     }
     return false;
 }
@@ -213,17 +294,21 @@ void run_backend(uint32_t bid) {
     AUDIT_LOG("  Backend: %s\n", ufsecp_gpu_backend_name(bid));
 
     uint8_t msg[32], pub[33], base[64];
-    if (!make_valid_row(sc, msg, pub, base)) {
-        AUDIT_LOG("  (ecdsa signing infra unavailable -- skip boundary differential)\n");
+    if (!make_small_valid_row(sc, msg, pub, base)) {
+        AUDIT_LOG("  (ufsecp_ecdsa_recover infra unavailable -- skip boundary differential)\n");
         ufsecp_ctx_destroy(sc);
         ufsecp_gpu_ctx_destroy(ctx);
         return;
     }
 
-    // Row corpus: (label, expected-by-CPU-strict-oracle).
+    // Row corpus: (label, expected-by-CPU-strict-oracle). Rows 1-3 are the
+    // congruent-malleation class of the small base -- representable in 32
+    // bytes because r = 1 and s = 0x0307 are far below 2^256 - n.
     std::vector<Row> rows;
-    rows.push_back({"valid base", true});
-    rows.push_back({"s + n (congruent malleation; representable iff s < 2^256-n)", false});
+    rows.push_back({"valid base (r=small, s=small)", true});
+    rows.push_back({"r, s+n (congruent malleation)", false});
+    rows.push_back({"r+n, s  (congruent malleation)", false});
+    rows.push_back({"r+n, s+n (congruent malleation)", false});
     rows.push_back({"r = n", false});
     rows.push_back({"s = n", false});
     rows.push_back({"r = n-1", false});
@@ -236,11 +321,8 @@ void run_backend(uint32_t bid) {
     const size_t M = rows.size();
     std::vector<uint8_t> dig(M * 32), pks(M * 33), sigs(M * 64);
 
-    // The s+n congruent-malleation row is representable only when the base
-    // s < 2^256 - n (a random canonical s is effectively never that small).
-    // When it does not fit we still exercise the row slot with a definite
-    // > n encoding and assert uniformity; the flag only drives the label.
-    bool has_sn_row = false;
+    // r/s := wildcard per-row; then the congruent rows get +n via 32-byte add.
+    bool all_congruent_representable = true;
     for (size_t i = 0; i < M; ++i) {
         std::memcpy(&dig[i * 32], msg, 32);
         std::memcpy(&pks[i * 33], pub, 33);
@@ -248,19 +330,26 @@ void run_backend(uint32_t bid) {
         copy32(base, r);
         copy32(base + 32, s);
         switch (i) {
-            case 0: break;  // base (valid low-S)
-            case 1: has_sn_row = be_add_order(base + 32, s); break;  // s := s + n
-            case 2: copy32(kOrderBe, r); break;
-            case 3: copy32(kOrderBe, s); break;
-            case 4: copy32(kOrderMinus1Be, r); break;
-            case 5: copy32(kOrderMinus1Be, s); break;
-            case 6: copy32(kZero32, r); break;
-            case 7: copy32(kZero32, s); break;
-            case 8: copy32(kMax32Be, r); break;
-            case 9: copy32(kMax32Be, s); break;
+            case 0: break;  // base (valid, small r/s)
+            case 1: break;  // (r, s+n)
+            case 2: break;  // (r+n, s)
+            case 3: break;  // (r+n, s+n)
+            case 4: copy32(kOrderBe, r); break;
+            case 5: copy32(kOrderBe, s); break;
+            case 6: copy32(kOrderMinus1Be, r); break;
+            case 7: copy32(kOrderMinus1Be, s); break;
+            case 8: copy32(kZero32, r); break;
+            case 9: copy32(kZero32, s); break;
+            case 10: copy32(kMax32Be, r); break;
+            case 11: copy32(kMax32Be, s); break;
             default: break;
         }
-        if (i == 1 && !has_sn_row) copy32(kMax32Be, s);  // s >= n either way
+        if (i == 1) all_congruent_representable &= be_add_order(base + 32, s);  // s := s+n
+        if (i == 2) all_congruent_representable &= be_add_order(base, r);        // r := r+n
+        if (i == 3) {
+            all_congruent_representable &= be_add_order(base + 32, s);           // s := s+n
+            all_congruent_representable &= be_add_order(base, r);                // r := r+n
+        }
         std::memcpy(&sigs[i * 64], r, 32);
         std::memcpy(&sigs[i * 64 + 32], s, 32);
 
@@ -268,12 +357,14 @@ void run_backend(uint32_t bid) {
         rows[i].want_valid = (ufsecp_ecdsa_verify(sc, msg, &sigs[i * 64], pub) == UFSECP_OK);
     }
 
-    // Sanity: the oracle itself is strict (base valid, malleation rejected).
-    CHECK(rows[0].want_valid, "[B] CPU oracle accepts the valid base row (strict parse)");
-    if (has_sn_row)
-        CHECK(!rows[1].want_valid, "[B] CPU oracle rejects the s+n congruent-malleation row (strict parse)");
-    else
-        AUDIT_LOG("  (note: base s >= 2^256-n, s+n malleation unrealizable at this seed; row pinned with s>=n)\n");
+    // With the small base the s+n / r+n classes MUST be representable: if this
+    // ever stops holding, the differential has silently lost its point.
+    CHECK(all_congruent_representable,
+          "[B] congruent-malleation rows (r, s+n)/(r+n, s)/(r+n, s+n) are all 32-byte-representable");
+    CHECK(rows[0].want_valid, "[B] CPU oracle accepts the recovered small-(r, s) base row");
+    CHECK(!rows[1].want_valid, "[B] CPU oracle rejects (r, s+n) (strict parse rejects s >= n)");
+    CHECK(!rows[2].want_valid, "[B] CPU oracle rejects (r+n, s) (strict parse rejects r >= n)");
+    CHECK(!rows[3].want_valid, "[B] CPU oracle rejects (r+n, s+n)");
 
     // ---- batch ----
     std::vector<uint8_t> batch(M, 2);
@@ -301,6 +392,18 @@ void run_backend(uint32_t bid) {
         CHECK(collect_match, "[B] collect verdict == CPU strict oracle per boundary row");
         CHECK(per_row,       "[B] collect == verify_batch verdict per boundary row");
         CHECK(seeded,        "[B] invalid rows are left at the seeded marker (fail-closed)");
+
+        // Explicit pins so a guard that rejects EVERYTHING cannot pass: the
+        // valid base must verify on both entrypoints and each congruent
+        // malleation must be rejected on both.
+        CHECK(batch[0] == 1u && key[0] == 0,
+              "[B] valid base accepted by BOTH verify_batch and ecdsa_verify_collect");
+        CHECK(batch[1] == 0u && key[1] == kSeed,
+              "[B] (r, s+n) rejected by BOTH entrypoints (collect cell stays seeded)");
+        CHECK(batch[2] == 0u && key[2] == kSeed,
+              "[B] (r+n, s) rejected by BOTH entrypoints (collect cell stays seeded)");
+        CHECK(batch[3] == 0u && key[3] == kSeed,
+              "[B] (r+n, s+n) rejected by BOTH entrypoints (collect cell stays seeded)");
     }
 
     ufsecp_ctx_destroy(sc);
@@ -320,7 +423,7 @@ void test_backend_differential() {
 
 }  // namespace
 
-int test_regression_gpu_ecdsa_compact_range_run() {
+int test_gpu_ecdsa_compact_range_run() {
     g_pass = 0; g_fail = 0;
     AUDIT_LOG("=== GPU ECDSA compact-sig strict-range regression ===\n");
     test_source_gate();
@@ -330,5 +433,5 @@ int test_regression_gpu_ecdsa_compact_range_run() {
 }
 
 #ifdef STANDALONE_TEST
-int main() { return test_regression_gpu_ecdsa_compact_range_run(); }
+int main() { return test_gpu_ecdsa_compact_range_run(); }
 #endif

--- a/audit/test_regression_gpu_ecdsa_compact_range.cpp
+++ b/audit/test_regression_gpu_ecdsa_compact_range.cpp
@@ -1,0 +1,334 @@
+/* ============================================================================
+ * UltrafastSecp256k1 -- GPU ECDSA compact-signature strict-range regression
+ * ============================================================================
+ * Consensus-relevant finding: for a compact ECDSA signature whose r or s is
+ * OUT of the scalar range [1, n-1] (i.e. r >= n or s >= n), the verification
+ * verdict was NOT uniform across the library's own paths:
+ *
+ *   CUDA  ecdsa_verify_batch_kernel     strict  (ecdsa_sig_parse_compact_strict)
+ *   CUDA  ecdsa_verify_collect_kernel   permissive (host bytes_to_ecdsa_sig +
+ *           ecdsa_verify, which only rejected zero scalars and reduced the
+ *           limbs mod n)
+ *   Metal ecdsa_verify_batch_compressed permissive (same mod-n reduction)
+ *   Metal lbtc_ecdsa_verify_collect     permissive (same mod-n reduction)
+ *   OpenCL ecdsa_verify_compressed/rows strict  (lbtc_parse_compact_signature)
+ *   CPU   ufsecp_ecdsa_verify           strict  (parse_compact_strict + low-S)
+ *
+ * For an encoding (r, s+n) with s+n < 2^256 the scalar s+n is congruent to s
+ * mod n, so the permissive paths returned the SAME verdict as for the valid
+ * (r, s) -- i.e. they accepted a non-canonical compact encoding that the
+ * strict paths reject. Ubiquitous txs use low-S, and ufsecp_ecdsa_sign only
+ * emits canonical r/s < n, so a valid base with s < 2^256 - n is infeasible to
+ * synthesize; the divergence is therefore mostly theoretical in the wild BUT
+ * it still breaks the documented invariant "collect EC verdict is bit-identical
+ * to verify_batch" (gpu_backend_cuda.cu, ecdsa_verify_collect_kernel) and the
+ * analogous invariant in the Metal shaders.
+ *
+ * FIX: each backend's device-side ecdsa_verify() entry point now rejects
+ * r >= n or s >= n up front (single choke point shared by single/batch/collect
+ * and the sign-and-verify countermeasure path), restoring one uniform strict
+ * compact contract across CPU, CUDA, OpenCL and Metal.
+ *
+ * This module pins the fix two ways:
+ *   [A] CPU-only SOURCE GATE (always runs, every runner): scans the in-tree
+ *       kernel sources and asserts the strict range guard is present in each
+ *       backend's ecdsa_verify() and that the CUDA batch kernel keeps its
+ *       strict parse. This FAILED against the pre-fix sources, so it is the
+ *       real always-bit-rot regression gate.
+ *   [B] On-device BOUNDARY-SCALAR differential (advisory; self-skips when no
+ *       GPU backend is available): feeds r/s on the {0, n-1, n, 2^256-1,
+ *       s+n-congruent class} boundaries through BOTH the batch and collect
+ *       entrypoints and asserts per-row uniformity with the CPU strict oracle.
+ *
+ * PUBLIC-DATA inputs only; verify is variable-time by design. No GPU needed to
+ * build/run the source gate; the on-device part self-skips cleanly (operational
+ * errors surface as SKIP, never a false PASS), mirroring
+ * test_gpu_collect_verify_parity.
+ * ============================================================================ */
+
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "ufsecp/ufsecp.h"
+#include "ufsecp/ufsecp_gpu.h"
+#include "audit_check.hpp"
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+namespace {
+
+// Group order n, big-endian 32 bytes (0xFFFFFFFF...D0364141).
+static const uint8_t kOrderBe[32] = {
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE,
+    0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B,
+    0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36, 0x41, 0x41
+};
+
+// n-1, big-endian.
+static const uint8_t kOrderMinus1Be[32] = {
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE,
+    0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B,
+    0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36, 0x41, 0x40
+};
+
+// 2^256 - 1, big-endian (all ones; > n).
+static const uint8_t kMax32Be[32] = {
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+};
+
+static const uint8_t kZero32[32] = {0};
+
+// s := s + n mod 2^256 (big-endian 32-byte add). Returns false if it would
+// overflow 32 bytes (encoding not representable). This is the s-congruent
+// malleation class; only representable when s < 2^256 - n.
+bool be_add_order(const uint8_t* s, uint8_t out[32]) {
+    unsigned carry = 0;
+    for (int i = 31; i >= 0; --i) {
+        unsigned v = (unsigned)s[i] + kOrderBe[i] + carry;
+        out[i] = (uint8_t)v;
+        carry = v >> 8;
+    }
+    return carry == 0;
+}
+
+// A backend runtime error (or a backend without the native entrypoints) means
+// "not assertable on this runner" -> treat as skip, never a false FAIL.
+bool is_skip_err(ufsecp_error_t e) {
+    return e == UFSECP_ERR_GPU_LAUNCH || e == UFSECP_ERR_GPU_MEMORY ||
+           e == UFSECP_ERR_GPU_BACKEND || e == UFSECP_ERR_GPU_QUEUE ||
+           e == UFSECP_ERR_GPU_DEVICE || e == UFSECP_ERR_GPU_UNSUPPORTED;
+}
+
+void copy32(const uint8_t src[32], uint8_t dst[32]) { std::memcpy(dst, src, 32); }
+
+// ---------------------------------------------------------------------------
+// [A] CPU-only source gate -- runs on EVERY runner, no GPU required. Each
+//     backend's device ecdsa_verify() must carry the strict >= n guard; the
+//     CUDA batch kernel must keep its strict compact parse. These CHECKs fail
+//     against the pre-fix sources, so this section trees the regression even
+//     on CPU-only CI (no GPU ever exercised it).
+// ---------------------------------------------------------------------------
+void test_source_gate() {
+    AUDIT_LOG("[gpu_ecdsa_compact_range] source gate (CPU-only, always runs)\n");
+
+    // -- CUDA: device ecdsa_verify() reject r/s >= n (ecdsa.cuh), and the
+    //    batch kernel keeps the strict compact parse (secp256k1.cu). ------
+    {
+        std::string cuh = audit_read_source_file("src/cuda/include/ecdsa.cuh");
+        CHECK(!cuh.empty(), "src/cuda/include/ecdsa.cuh must be readable (in-tree source)");
+        if (!cuh.empty()) {
+            CHECK(cuh.find("scalar_ge(&sig->r, ORDER)") != std::string::npos,
+                  "[A] CUDA ecdsa_verify rejects r >= n (scalar_ge guard)");
+            CHECK(cuh.find("scalar_ge(&sig->s, ORDER)") != std::string::npos,
+                  "[A] CUDA ecdsa_verify rejects s >= n (scalar_ge guard)");
+        }
+        std::string cu = audit_read_source_file("src/cuda/src/secp256k1.cu");
+        CHECK(!cu.empty(), "src/cuda/src/secp256k1.cu must be readable (in-tree source)");
+        if (!cu.empty()) {
+            CHECK(cu.find("ecdsa_sig_parse_compact_strict") != std::string::npos,
+                  "[A] CUDA batch kernel keeps strict compact parse (parse_compact_strict)");
+        }
+    }
+
+    // -- Metal: ecdsa_verify() reject r/s >= n (secp256k1_extended.h) via the
+    //    scalar256_ge_n() helper that compares limbs against SECP256K1_N. --
+    {
+        std::string mh = audit_read_source_file("src/metal/shaders/secp256k1_extended.h");
+        CHECK(!mh.empty(), "src/metal/shaders/secp256k1_extended.h must be readable (in-tree source)");
+        if (!mh.empty()) {
+            CHECK(mh.find("inline bool scalar256_ge_n") != std::string::npos,
+                  "[A] Metal defines scalar256_ge_n() range helper");
+            CHECK(mh.find("scalar256_ge_n(sig.r)") != std::string::npos,
+                  "[A] Metal ecdsa_verify rejects r >= n (scalar256_ge_n guard)");
+            CHECK(mh.find("scalar256_ge_n(sig.s)") != std::string::npos,
+                  "[A] Metal ecdsa_verify rejects s >= n (scalar256_ge_n guard)");
+        }
+    }
+
+    // -- OpenCL: ecdsa_verify_impl() reject r/s >= n (secp256k1_extended.cl)
+    //    using the same lbtc_scalar_ge_order() primitive the strict compact
+    //    parser already uses. ----------------------------------------------
+    {
+        std::string cl = audit_read_source_file("src/opencl/kernels/secp256k1_extended.cl");
+        CHECK(!cl.empty(), "src/opencl/kernels/secp256k1_extended.cl must be readable (in-tree source)");
+        if (!cl.empty()) {
+            CHECK(cl.find("lbtc_scalar_ge_order(&sig->r)") != std::string::npos,
+                  "[A] OpenCL ecdsa_verify_impl rejects r >= n (lbtc_scalar_ge_order guard)");
+            CHECK(cl.find("lbtc_scalar_ge_order(&sig->s)") != std::string::npos,
+                  "[A] OpenCL ecdsa_verify_impl rejects s >= n (lbtc_scalar_ge_order guard)");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [B] On-device boundary-scalar differential (advisory; self-skips w/o GPU).
+//     Builds one valid compressed compact row plus a family of boundary
+//     encodings and asserts the batch/collect per-row verdicts are uniform with
+//     the CPU strict oracle (ufsecp_ecdsa_verify: parse_compact_strict + low-S).
+// ---------------------------------------------------------------------------
+struct Row {
+    const char* label;
+    bool       want_valid;   // expected per the CPU strict oracle
+};
+
+// Deterministically produce a LOW-S compact signature accepted by the CPU
+// strict oracle. Returns false if signing/verification infra is unavailable.
+bool make_valid_row(ufsecp_ctx* sc, uint8_t msg[32], uint8_t pub33[33],
+                    uint8_t sig64[64]) {
+    for (int seed = 0; seed < 32; ++seed) {
+        uint8_t sk[32] = {0};
+        sk[31] = (uint8_t)(seed * 7 + 3);
+        sk[30] = (uint8_t)(seed * 13 + 1);
+        for (int j = 0; j < 32; ++j)
+            msg[j] = (uint8_t)(seed * 29 + j * 11 + 5);
+        if (ufsecp_pubkey_create(sc, sk, pub33) != UFSECP_OK) return false;
+        if (ufsecp_ecdsa_sign(sc, msg, sk, sig64) != UFSECP_OK) continue;
+        if (ufsecp_ecdsa_verify(sc, msg, sig64, pub33) == UFSECP_OK) return true;
+    }
+    return false;
+}
+
+// Build the boundary corpus and run batch+collect on one backend id.
+void run_backend(uint32_t bid) {
+    ufsecp_gpu_ctx* ctx = nullptr;
+    if (ufsecp_gpu_ctx_create(&ctx, bid, 0) != UFSECP_OK || !ctx) {
+        AUDIT_LOG("  (%s: ctx create failed -- skipping)\n", ufsecp_gpu_backend_name(bid));
+        return;
+    }
+    ufsecp_ctx* sc = nullptr;
+    if (ufsecp_ctx_create(&sc) != UFSECP_OK || !sc) {
+        AUDIT_LOG("  (%s: cpu ctx create failed -- skipping)\n", ufsecp_gpu_backend_name(bid));
+        ufsecp_gpu_ctx_destroy(ctx);
+        return;
+    }
+    AUDIT_LOG("  Backend: %s\n", ufsecp_gpu_backend_name(bid));
+
+    uint8_t msg[32], pub[33], base[64];
+    if (!make_valid_row(sc, msg, pub, base)) {
+        AUDIT_LOG("  (ecdsa signing infra unavailable -- skip boundary differential)\n");
+        ufsecp_ctx_destroy(sc);
+        ufsecp_gpu_ctx_destroy(ctx);
+        return;
+    }
+
+    // Row corpus: (label, expected-by-CPU-strict-oracle).
+    std::vector<Row> rows;
+    rows.push_back({"valid base", true});
+    rows.push_back({"s + n (congruent malleation; representable iff s < 2^256-n)", false});
+    rows.push_back({"r = n", false});
+    rows.push_back({"s = n", false});
+    rows.push_back({"r = n-1", false});
+    rows.push_back({"s = n-1", false});
+    rows.push_back({"r = 0", false});
+    rows.push_back({"s = 0", false});
+    rows.push_back({"r = 2^256-1", false});
+    rows.push_back({"s = 2^256-1", false});
+
+    const size_t M = rows.size();
+    std::vector<uint8_t> dig(M * 32), pks(M * 33), sigs(M * 64);
+
+    // The s+n congruent-malleation row is representable only when the base
+    // s < 2^256 - n (a random canonical s is effectively never that small).
+    // When it does not fit we still exercise the row slot with a definite
+    // > n encoding and assert uniformity; the flag only drives the label.
+    bool has_sn_row = false;
+    for (size_t i = 0; i < M; ++i) {
+        std::memcpy(&dig[i * 32], msg, 32);
+        std::memcpy(&pks[i * 33], pub, 33);
+        uint8_t r[32], s[32];
+        copy32(base, r);
+        copy32(base + 32, s);
+        switch (i) {
+            case 0: break;  // base (valid low-S)
+            case 1: has_sn_row = be_add_order(base + 32, s); break;  // s := s + n
+            case 2: copy32(kOrderBe, r); break;
+            case 3: copy32(kOrderBe, s); break;
+            case 4: copy32(kOrderMinus1Be, r); break;
+            case 5: copy32(kOrderMinus1Be, s); break;
+            case 6: copy32(kZero32, r); break;
+            case 7: copy32(kZero32, s); break;
+            case 8: copy32(kMax32Be, r); break;
+            case 9: copy32(kMax32Be, s); break;
+            default: break;
+        }
+        if (i == 1 && !has_sn_row) copy32(kMax32Be, s);  // s >= n either way
+        std::memcpy(&sigs[i * 64], r, 32);
+        std::memcpy(&sigs[i * 64 + 32], s, 32);
+
+        // CPU strict oracle for this row.
+        rows[i].want_valid = (ufsecp_ecdsa_verify(sc, msg, &sigs[i * 64], pub) == UFSECP_OK);
+    }
+
+    // Sanity: the oracle itself is strict (base valid, malleation rejected).
+    CHECK(rows[0].want_valid, "[B] CPU oracle accepts the valid base row (strict parse)");
+    if (has_sn_row)
+        CHECK(!rows[1].want_valid, "[B] CPU oracle rejects the s+n congruent-malleation row (strict parse)");
+    else
+        AUDIT_LOG("  (note: base s >= 2^256-n, s+n malleation unrealizable at this seed; row pinned with s>=n)\n");
+
+    // ---- batch ----
+    std::vector<uint8_t> batch(M, 2);
+    ufsecp_error_t eb = ufsecp_gpu_ecdsa_verify_batch(ctx, dig.data(), pks.data(), sigs.data(), M, batch.data());
+    if (is_skip_err(eb)) { AUDIT_LOG("  (ecdsa batch: runtime skip %d (%s))\n", eb, ufsecp_gpu_error_str(eb)); ufsecp_ctx_destroy(sc); ufsecp_gpu_ctx_destroy(ctx); return; }
+    CHECK(eb == UFSECP_OK, "[B] verify_batch boundary corpus -> OK");
+
+    // ---- collect ----
+    const uint8_t kSeed = 0xEE;
+    std::vector<uint8_t> key(M, kSeed);
+    ufsecp_error_t ec = ufsecp_gpu_ecdsa_verify_collect(ctx, dig.data(), pks.data(), sigs.data(), M, key.data());
+    if (is_skip_err(ec)) { AUDIT_LOG("  (ecdsa collect: runtime skip %d (%s))\n", ec, ufsecp_gpu_error_str(ec)); ufsecp_ctx_destroy(sc); ufsecp_gpu_ctx_destroy(ctx); return; }
+    CHECK(ec == UFSECP_OK, "[B] ecdsa_verify_collect boundary corpus -> OK");
+
+    if (eb == UFSECP_OK && ec == UFSECP_OK) {
+        bool batch_match = true, collect_match = true, per_row = true, seeded = true;
+        for (size_t i = 0; i < M; ++i) {
+            const bool ok = rows[i].want_valid;
+            if (batch[i] != (ok ? 1u : 0u)) batch_match = false;
+            if ((key[i] == 0) != ok) collect_match = false;
+            if ((key[i] == 0) != (batch[i] == 1)) per_row = false;
+            if (!ok && key[i] != kSeed) seeded = false;   // invalid row stays seeded
+        }
+        CHECK(batch_match,   "[B] batch verdict == CPU strict oracle per boundary row");
+        CHECK(collect_match, "[B] collect verdict == CPU strict oracle per boundary row");
+        CHECK(per_row,       "[B] collect == verify_batch verdict per boundary row");
+        CHECK(seeded,        "[B] invalid rows are left at the seeded marker (fail-closed)");
+    }
+
+    ufsecp_ctx_destroy(sc);
+    ufsecp_gpu_ctx_destroy(ctx);
+}
+
+void test_backend_differential() {
+    AUDIT_LOG("[gpu_ecdsa_compact_range] boundary-scalar differential (if GPU available)\n");
+    uint32_t ids[8] = {};
+    const uint32_t n = ufsecp_gpu_backend_count(ids, 8);
+    bool any = false;
+    for (uint32_t i = 0; i < n; ++i) {
+        if (ufsecp_gpu_is_available(ids[i])) { any = true; run_backend(ids[i]); }
+    }
+    if (!any) AUDIT_LOG("  (no GPU available -- skipping on-device differential)\n");
+}
+
+}  // namespace
+
+int test_regression_gpu_ecdsa_compact_range_run() {
+    g_pass = 0; g_fail = 0;
+    AUDIT_LOG("=== GPU ECDSA compact-sig strict-range regression ===\n");
+    test_source_gate();
+    test_backend_differential();
+    AUDIT_LOG("[gpu_ecdsa_compact_range] pass=%d fail=%d\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}
+
+#ifdef STANDALONE_TEST
+int main() { return test_regression_gpu_ecdsa_compact_range_run(); }
+#endif

--- a/audit/unified_audit_runner.cpp
+++ b/audit/unified_audit_runner.cpp
@@ -163,6 +163,7 @@ int test_gpu_abi_gate_run();          // Discovery, lifecycle, ops-if-available
 int test_gpu_zk_prove_verify_differential_run(); // CPU range-proof → GPU poly-check accept/reject
 int test_gpu_lbtc_columns_diff_run(); // GPU vs CPU lbtc columns + engine dispatcher fallback
 int test_gpu_collect_verify_parity_run(); // native collect verdict == verify_batch verdict (per-row)
+int test_regression_gpu_ecdsa_compact_range_run(); // GPU ECDSA strict r/s<n range: source gate + boundary differential
 int test_regression_hash256_var_batch_run(); // hash256_var batch structural/boundary KAT vs SHA256::hash256 oracle
 int test_regression_hash256_var_parity_run(); // hash256_var cross-backend (CUDA/OpenCL/Metal) byte-identical parity
 int test_regression_merkle_pair_hash_run(); // merkle_pair_hash structural/boundary KAT + cross-backend parity vs SHA256::hash256 oracle
@@ -941,6 +942,11 @@ static const AuditModule ALL_MODULES[] = {
     // the on-device collect-vs-verify_batch per-row parity self-skips when no GPU
     // backend is present (or a backend lacks a native collect override).
     { "gpu_collect_verify_parity", "GPU collect-verify parity (native OpenCL/Metal/CUDA collect == verify_batch verdict)", "differential", test_gpu_collect_verify_parity_run, false },
+    // advisory=false: the CPU-only source gate scans the in-tree kernel sources
+    // and MUST pass everywhere (it failed against the pre-fix permissive
+    // ecdsa_verify paths); the on-device boundary-scalar differential
+    // self-skips when no GPU backend is available.
+    { "gpu_ecdsa_compact_range", "GPU ECDSA compact-sig strict r/s<n range (source gate + boundary-scalar differential)", "differential", test_regression_gpu_ecdsa_compact_range_run, false },
     // advisory=false: null-ctx contract runs CPU-only and MUST pass everywhere;
     // the on-device KAT/boundary checks (per backend) self-skip when no GPU
     // backend is compiled in or a device is unavailable.

--- a/audit/unified_audit_runner.cpp
+++ b/audit/unified_audit_runner.cpp
@@ -163,7 +163,7 @@ int test_gpu_abi_gate_run();          // Discovery, lifecycle, ops-if-available
 int test_gpu_zk_prove_verify_differential_run(); // CPU range-proof → GPU poly-check accept/reject
 int test_gpu_lbtc_columns_diff_run(); // GPU vs CPU lbtc columns + engine dispatcher fallback
 int test_gpu_collect_verify_parity_run(); // native collect verdict == verify_batch verdict (per-row)
-int test_regression_gpu_ecdsa_compact_range_run(); // GPU ECDSA strict r/s<n range: source gate + boundary differential
+int test_gpu_ecdsa_compact_range_run(); // GPU ECDSA strict r/s<n range: source gate + boundary differential
 int test_regression_hash256_var_batch_run(); // hash256_var batch structural/boundary KAT vs SHA256::hash256 oracle
 int test_regression_hash256_var_parity_run(); // hash256_var cross-backend (CUDA/OpenCL/Metal) byte-identical parity
 int test_regression_merkle_pair_hash_run(); // merkle_pair_hash structural/boundary KAT + cross-backend parity vs SHA256::hash256 oracle
@@ -946,7 +946,7 @@ static const AuditModule ALL_MODULES[] = {
     // and MUST pass everywhere (it failed against the pre-fix permissive
     // ecdsa_verify paths); the on-device boundary-scalar differential
     // self-skips when no GPU backend is available.
-    { "gpu_ecdsa_compact_range", "GPU ECDSA compact-sig strict r/s<n range (source gate + boundary-scalar differential)", "differential", test_regression_gpu_ecdsa_compact_range_run, false },
+    { "gpu_ecdsa_compact_range", "GPU ECDSA compact-sig strict r/s<n range (source gate + boundary-scalar differential)", "differential", test_gpu_ecdsa_compact_range_run, false },
     // advisory=false: null-ctx contract runs CPU-only and MUST pass everywhere;
     // the on-device KAT/boundary checks (per backend) self-skip when no GPU
     // backend is compiled in or a device is unavailable.

--- a/docs/ARM64_AUDIT_BENCHMARK.md
+++ b/docs/ARM64_AUDIT_BENCHMARK.md
@@ -284,7 +284,7 @@ ctest --test-dir build --output-on-failure
 ## ✅ Audit Test Results (Android ARM64)
 
 **Full audit run:** 48/49 modules passed  
-**Advisory warning:** Side-channel dudect smoke test ( 475 modules)
+**Advisory warning:** Side-channel dudect smoke test ( 476 modules)
 - **Reason:** Probabilistic timing test, flakes under shared CPU scheduler on mobile OS
 - **Mitigation:** Dedicated CT verification on Apple Silicon M1 native (controlled environment)
 - **Verdict:** Not a security issue, advisory only

--- a/docs/ATTACK_GUIDE.md
+++ b/docs/ATTACK_GUIDE.md
@@ -4,7 +4,7 @@
 > or prove we missed something — start here. We want you to find real bugs more
 > than we want to look clean.
 
-**Current assurance state**: 276 exploit PoCs modules + 199 non-exploit modules = 475 total
+**Current assurance state**: 276 exploit PoCs modules + 200 non-exploit modules = 476 total
 (via `audit/unified_audit_runner`), 11 fuzzer harnesses, dudect
 + Valgrind CT evidence, full Wycheproof vector coverage. None of this means the library is bug-free.
 It means we tried hard. Now you try.

--- a/docs/AUDIT_COVERAGE.md
+++ b/docs/AUDIT_COVERAGE.md
@@ -9,7 +9,7 @@
 |------|---------|
 | Audit checks per run | ~1,000,000+ |
 | Nightly random checks | ~1,300,000+ |
-| Audit modules | 475 across 9 failure classes |
+| Audit modules | 476 across 9 failure classes |
 | Exploit PoC tests | 276 exploit-PoC modules, 200+ attack vectors |
 | Platforms | X64, ARM64, RISC-V, macOS, Windows, iOS, Android, WASM, ROCm (16 configurations) |
 | Fuzz inputs | seed corpus: ~530K entries (runtime corpus grows dynamically) |
@@ -34,7 +34,7 @@ This system continuously verifies correctness across math, protocol, constant-ti
 
 **Version**: v4.1.0
 **Audit Runner**: `unified_audit_runner`
-**Verdict**: **CAAS Self-Audit Verdict: AUDIT-READY (self-generated continuous audit; no external third-party security audit has been completed)** -- 475 modules, 9 failure classes
+**Verdict**: **CAAS Self-Audit Verdict: AUDIT-READY (self-generated continuous audit; no external third-party security audit has been completed)** -- 476 modules, 9 failure classes
 **Total Checks**: ~1,000,000+ (audit) + 1.3M+ (nightly differential)
 **CT Verification**: Three-tier -- ct-verif (LLVM IR) + Valgrind CT + dudect (available as `workflow_dispatch` GitHub Actions + local dudect; triggered manually, **not** on every commit push -- matches README "Constant-time verification pipelines" row)
 
@@ -45,7 +45,7 @@ This system continuously verifies correctness across math, protocol, constant-ti
 | Metric               | Value                                       |
 |----------------------|---------------------------------------------|
 | Audit Sections       | 8                                           |
-| Audit Modules        | 199 (non-exploit modules) |
+| Audit Modules        | 200 (non-exploit modules) |
 | **Exploit PoC Tests** | **276 tests across 20+ attack categories** (`audit/test_exploit_*.cpp`) |
 | Audit assertions     | ~1,000,000+ (parser fuzz 530K, CT deep 120K, field Fp 264K, ZK ~1.5K, ...) |
 | Nightly differential | ~1,300,000+ additional random checks (daily) |

--- a/docs/AUDIT_GUIDE.md
+++ b/docs/AUDIT_GUIDE.md
@@ -17,7 +17,7 @@ The security model is CAAS-first: claims are strengthened by executable
 evidence and permanent regression tests.
 Internal audit is part of normal development and is expected to run on every build and every commit through the CI and local audit workflow.
 
-### What It Tests ( 199 non-exploit modules + 276 exploit PoC tests + standalone audit surfaces)
+### What It Tests ( 200 non-exploit modules + 276 exploit PoC tests + standalone audit surfaces)
 
 | Section | Modules | Focus |
 |---------|---------|-------|
@@ -220,7 +220,7 @@ In addition to the CPU `unified_audit_runner`, each GPU backend has its own
 audit runner that exercises GPU kernel correctness. These are separate from
 the CPU audit and test GPU-specific code paths.
 
-### OpenCL Audit Runner ( 475 modules, 8 sections)
+### OpenCL Audit Runner ( 476 modules, 8 sections)
 
 ```bash
 # Build
@@ -234,7 +234,7 @@ Output: `ocl_audit_report.json` + `ocl_audit_report.txt`
 
 Requires an OpenCL-capable GPU (NVIDIA, AMD, Intel).
 
-### Metal Audit Runner ( 475 modules, 8 sections)
+### Metal Audit Runner ( 476 modules, 8 sections)
 
 ```bash
 # Build (macOS only)
@@ -363,8 +363,8 @@ to compare both paths on the same inputs.
 | `tests/esp32_audit/` | ESP32-S3 port of the audit |
 | `docker/Dockerfile.ci` | CI container for automated auditing |
 | `.github/workflows/audit-report.yml` | GitHub Actions audit workflow |
-| `opencl/src/opencl_audit_runner.cpp` | OpenCL GPU audit runner ( 475 modules) |
-| `metal/src/metal_audit_runner.mm` | Metal GPU audit runner ( 475 modules) |
+| `opencl/src/opencl_audit_runner.cpp` | OpenCL GPU audit runner ( 476 modules) |
+| `metal/src/metal_audit_runner.mm` | Metal GPU audit runner ( 476 modules) |
 | `metal/CMakeLists.txt` | Metal build config (incl. audit runner target) |
 | `ci/security_autonomy_check.py` | Master Security Autonomy orchestrator (10 gates, score 0-100) |
 | `docs/SECURITY_AUTONOMY_PLAN.md` | 30-day security autonomy framework and phase plan |

--- a/docs/AUDIT_READINESS_REPORT_v1.md
+++ b/docs/AUDIT_READINESS_REPORT_v1.md
@@ -315,7 +315,7 @@ cmake -S . -B out/release -G Ninja -DCMAKE_BUILD_TYPE=Release \
   -DSECP256K1_BUILD_PROTOCOL_TESTS=ON
 cmake --build out/release -j
 
-# === ONE-COMMAND FULL AUDIT ( 475 modules, 9 failure classes, ~10 min) ===
+# === ONE-COMMAND FULL AUDIT ( 476 modules, 9 failure classes, ~10 min) ===
 ./build/audit/unified_audit_runner
 
 # === Individual verification paths ===

--- a/docs/AUDIT_SCOPE.md
+++ b/docs/AUDIT_SCOPE.md
@@ -177,7 +177,7 @@ cmake -S . -B build_audit -G Ninja -DCMAKE_BUILD_TYPE=Release \
 # Build
 cmake --build build_audit -j
 
-# === FULL AUDIT ( 475 modules, 9 failure classes, ~10 min) ===
+# === FULL AUDIT ( 476 modules, 9 failure classes, ~10 min) ===
 ./build_audit/audit/unified_audit_runner
 
 # Run all CTest targets

--- a/docs/AUDIT_TRACEABILITY.md
+++ b/docs/AUDIT_TRACEABILITY.md
@@ -463,9 +463,9 @@ DIFFERENTIAL_MULTIPLIER=100 ./build/src/cpu/test_cross_libsecp256k1  # 1.3M chec
 | `gpu_backend_matrix` | Backend enumeration, device info, per-backend op probing | `audit/test_gpu_backend_matrix.cpp` |
 
 Backend-specific internal audit runners:
-- CUDA: `src/cuda/src/gpu_audit_runner.cu` ( 475 modules)
-- OpenCL: `opencl/src/opencl_audit_runner.cpp` ( 475 modules)
-- Metal: `metal/src/metal_audit_runner.mm` ( 475 modules)
+- CUDA: `src/cuda/src/gpu_audit_runner.cu` ( 476 modules)
+- OpenCL: `opencl/src/opencl_audit_runner.cpp` ( 476 modules)
+- Metal: `metal/src/metal_audit_runner.mm` ( 476 modules)
 
 ---
 

--- a/docs/BACKEND_PARITY.md
+++ b/docs/BACKEND_PARITY.md
@@ -13,7 +13,7 @@ This document tracks feature parity, audit coverage, and benchmark evidence acro
 | **CMake option** | `SECP256K1_BUILD_CPU` (ON) | `SECP256K1_BUILD_CUDA` (OFF) | `SECP256K1_BUILD_OPENCL` (OFF) | `SECP256K1_BUILD_METAL` (OFF) |
 | **Language** | C++20 | CUDA C++ | C99 (.cl kernels) | Metal Shading Language + ObjC++ |
 | **Interface** | `fastsecp256k1` static lib | `secp256k1_cuda_lib` | `secp256k1_opencl` | `secp256k1_metal_lib` |
-| **Audit runner** | `unified_audit_runner` (199 non-exploit + 276 exploit PoCs = 475 modules) | `gpu_audit_runner` ( 475 modules) | `opencl_audit_runner` ( 475 modules) | `metal_audit_runner` ( 475 modules) |
+| **Audit runner** | `unified_audit_runner` (200 non-exploit + 276 exploit PoCs = 476 modules) | `gpu_audit_runner` ( 476 modules) | `opencl_audit_runner` ( 476 modules) | `metal_audit_runner` ( 476 modules) |
 | **Benchmark** | `bench_unified` (8 categories) | `gpu_bench_unified` + 4 specialized | `opencl_benchmark` | `metal_secp256k1_bench_full` |
 | **CTest targets** | 18 core + 27 audit | 3 (`cuda_selftest`, `gpu_audit`, `gpu_ct_smoke`) | 2 (`opencl_selftest`, `opencl_audit`) | 5 (`metal_host_test`, `secp256k1_metal_test`, `secp256k1_metal_bench`, `secp256k1_metal_bench_full`, `secp256k1_metal_audit`) |
 | **Tested hardware** | x86-64, ARM64, RISC-V, ESP32-S3/P4/C6 | RTX 5060 Ti, RTX 4090, RTX 3090 | RTX 5060 Ti (via NVIDIA OpenCL) | Apple M3 Pro, M1 (CI) |

--- a/docs/CROSS_PLATFORM_TEST_MATRIX.md
+++ b/docs/CROSS_PLATFORM_TEST_MATRIX.md
@@ -34,7 +34,7 @@
 | 20 | gpu_audit              | GPU                 | ~300   | CUDA GPU unified audit (all modules)                             |
 | 21 | gpu_ct_smoke           | GPU                 | ~9     | CUDA CT smoke: ZK knowledge + DLEQ prove/verify                 |
 | 22 | opencl_selftest        | GPU                 | ~50    | OpenCL GPU kernel selftest                                       |
-| 23 | opencl_audit           | GPU                 | ~300   | OpenCL GPU unified audit ( 475 modules, 8 sections)               |
+| 23 | opencl_audit           | GPU                 | ~300   | OpenCL GPU unified audit ( 476 modules, 8 sections)               |
 | 24 | ct_sidechannel         | Constant-Time       | ~300   | Full CT: dudect Welch t-test, 600s timeout                      |
 | 25 | ct_sidechannel_smoke   | Constant-Time       | ~100   | CT smoke: basic correctness, 120s CI-safe                       |
 | 26 | differential           | Differential Test   | ~200   | Differential testing: fast vs CT layer output equivalence        |
@@ -178,7 +178,7 @@ Individual check counts:
   fiat_crypto_linkage ....... ~50  checks
   audit_fuzz ................ ~500 checks
   diag_scalar_mul ........... ~50  checks
-  unified_audit ............. 475 modules (199 non-exploit + 276 exploit PoCs)
+  unified_audit ............. 476 modules (200 non-exploit + 276 exploit PoCs)
   -----------------------------------------
   TOTAL (estimated):         ~6400+ individual assertions
 ```

--- a/docs/CT_VERIFICATION.md
+++ b/docs/CT_VERIFICATION.md
@@ -521,7 +521,7 @@ The OpenCL CT layer mirrors the CUDA CT implementation with OpenCL-native barrie
 - `value_barrier()` via inline OpenCL `asm volatile` or volatile loads
 - Branchless masks and conditional moves on all secret-dependent paths
 - CT scalar multiplication with fixed iteration count (GLV + signed-digit)
-- Audited via `opencl_audit_runner` ( 475 modules including CT sections)
+- Audited via `opencl_audit_runner` ( 476 modules including CT sections)
 
 ### Metal CT Layer
 
@@ -534,7 +534,7 @@ src/metal/shaders/
 The Metal CT layer uses Metal Shading Language (MSL) with:
 - `value_barrier()` via threadgroup memory fence pattern
 - Identical algorithms to CUDA/OpenCL CT layers
-- Audited via `metal_audit_runner` ( 475 modules including CT sections)
+- Audited via `metal_audit_runner` ( 476 modules including CT sections)
 
 ---
 
@@ -795,8 +795,8 @@ fixed iteration counts. All three GPU backends implement identical CT algorithms
 
 The GPU CT layers are tested via:
 - **CUDA**: `test_ct_smoke` (9 functional tests) + GPU audit runner (Section S6: CT Analysis)
-- **OpenCL**: `opencl_audit_runner` ( 475 modules including CT signing + CT ZK sections)
-- **Metal**: `metal_audit_runner` ( 475 modules including CT signing + CT ZK sections)
+- **OpenCL**: `opencl_audit_runner` ( 476 modules including CT signing + CT ZK sections)
+- **Metal**: `metal_audit_runner` ( 476 modules including CT signing + CT ZK sections)
 
 ### 5. Experimental Protocols
 

--- a/docs/CT_VERIFICATION.md
+++ b/docs/CT_VERIFICATION.md
@@ -41,6 +41,31 @@ lifetime, both cache modes) and `regression_precompute_noop_reconfigure`
 (PNR-1..4, with a negative control proving a real config change still
 invalidates).
 
+### 2026-09-10 GPU compact-ECDSA strict-range guard — public-data boundary, no CT boundary moved
+
+Three files the secret-path gate classifies as CT secret-bearing surfaces gained
+a guard for public compact-signature scalars; this section answers that
+classification rather than waiving it.
+
+- **`src/cuda/include/ecdsa.cuh`**, **`src/metal/shaders/secp256k1_extended.h`**,
+  **`src/opencl/kernels/secp256k1_extended.cl`**: `ecdsa_verify()` on each GPU
+  backend now rejects a compact signature with `r >= n` or `s >= n` up front,
+  before the `scalar_inverse()` call, so every verify route (single, batch,
+  collect, sign-and-verify) shares one strict compact contract. The CUDA batch
+  path keeps its strict `ecdsa_sig_parse_compact_strict` parse.
+- **CT status: unchanged.** The guard compares the two public scalars `r`, `s`
+  of the already-parsed 64-byte compact signature against the group order `n`.
+  Both are public data; the comparisons are public-data (variable-time is
+  permitted for them), and no secret value reaches a new branch or memory
+  access. No CT primitive changed, no constant-time code path was made
+  variable-time, and the failure exits return before the verify math that
+  touches secret-path state.
+- Pinned by `gpu_ecdsa_compact_range` — `[A]` CPU-only source gate asserts the
+  guard sits inside each backend's `ecdsa_verify()` body before
+  `scalar_inverse()` (kills any helper-stranding regression), `[B]` on-device
+  small-`(r,s)` boundary differential through batch and collect vs the CPU
+  strict oracle. Identity with the entry in `docs/SECURITY_CLAIMS.md`.
+
 ### 2026-06-01 ct_sign.cpp — variable-length Schnorr CT sign overload (SHIM-001 restore)
 
 - **`src/cpu/src/ct_sign.cpp`**: added a variable-length overload

--- a/docs/HARDWARE_SIDE_CHANNEL_METHODOLOGY.md
+++ b/docs/HARDWARE_SIDE_CHANNEL_METHODOLOGY.md
@@ -71,7 +71,7 @@ attacker access):
 
 | Test | Coverage |
 |------|----------|
-| `audit/test_ct_*` ( 475 modules in `ct_analysis` section) | dudect / Valgrind / ct-verif / CT IR diff |
+| `audit/test_ct_*` ( 476 modules in `ct_analysis` section) | dudect / Valgrind / ct-verif / CT IR diff |
 | `audit/test_exploit_timing_*` series | timing-channel exploit PoCs |
 | `gpu_ct_leakage_report.json` | GPU CT survey (public-data-only confirms no secret crosses GPU boundary) |
 | `audit/test_constant_time_field_ops.cpp` | per-primitive CT proof |

--- a/docs/SECRET_LIFECYCLE.md
+++ b/docs/SECRET_LIFECYCLE.md
@@ -1,6 +1,28 @@
 # Secret Lifecycle Review
 
-**Last updated**: 2026-09-07 | **Version**: 4.5.0
+**Last updated**: 2026-09-10 | **Version**: 4.5.0
+
+### 2026-09-10 - GPU compact-ECDSA strict-range guard (`src/cuda/include/ecdsa.cuh`, Metal shader, OpenCL kernel): no secret lifecycle change
+
+`ecdsa_verify()` on each GPU backend now rejects a compact signature whose `r >= n`
+or `s >= n` before any verification work. The gate-watched surfaces touched are
+the GPU verify sources and `CHANGELOG.md`; this entry answers the classification
+rather than waiving it.
+
+**Secret-buffer and zeroization verdict: unchanged.** The guard operates on the
+two public scalars of the already-parsed 64-byte compact signature. No new
+resident secret buffer is created and no `secure_erase` site is added or removed;
+the failure exits return before the verify math that would allocate
+secret-path state.
+
+**Fail-closed input handling.** In section `[B]` of
+`audit/test_regression_gpu_ecdsa_compact_range.cpp` the collect key buffer is
+seeded with `0xEE` and the test asserts each `r >= n` / `s >= n` row is left
+exactly at that seed — invalid inputs write no state a later collect step could
+mistake for a verdict. This matches the existing ABI contract that invalid
+inputs must not partially mutate secret or verdict buffers. Compare the SHA-256
+message-comparison guard in `src/gpu/src/gpu_backend_cuda.cu`, which already
+specified the fail-closed collect contract this alignment restores.
 
 ### 2026-09-07 - Affine-materialisation / in-place / RFC-6979-midstate wave: two secure_erase sites removed, one process-lifetime static added
 

--- a/docs/SECRET_LIFECYCLE.md
+++ b/docs/SECRET_LIFECYCLE.md
@@ -16,13 +16,13 @@ the failure exits return before the verify math that would allocate
 secret-path state.
 
 **Fail-closed input handling.** In section `[B]` of
-`audit/test_regression_gpu_ecdsa_compact_range.cpp` the collect key buffer is
+`audit/test_gpu_ecdsa_compact_range.cpp` the collect key buffer is
 seeded with `0xEE` and the test asserts each `r >= n` / `s >= n` row is left
 exactly at that seed — invalid inputs write no state a later collect step could
-mistake for a verdict. This matches the existing ABI contract that invalid
-inputs must not partially mutate secret or verdict buffers. Compare the SHA-256
+mistake for a verdict. This matches the existing gather/collect contract that
+invalid inputs must not partially mutate secret or verdict buffers. Compare the SHA-256
 message-comparison guard in `src/gpu/src/gpu_backend_cuda.cu`, which already
-specified the fail-closed collect contract this alignment restores.
+specified the fail-closed collect contract this regression restores.
 
 ### 2026-09-07 - Affine-materialisation / in-place / RFC-6979-midstate wave: two secure_erase sites removed, one process-lifetime static added
 

--- a/docs/SECURITY_CLAIMS.md
+++ b/docs/SECURITY_CLAIMS.md
@@ -2,6 +2,45 @@
 
 **UltrafastSecp256k1 v4.5.0** -- FAST / CT Dual-Layer Architecture (CPU + GPU)
 
+### 2026-09-10 - Strict compact-ECDSA range (`r`,`s` in `[1, n-1]`) enforced uniformly on every GPU verify path
+
+The compact-ECDSA strictness guard added in this wave is a verification-contract
+alignment, not a CT boundary change. It is recorded here because the secret-path
+gate classifies the GPU verify sources and `CHANGELOG.md` as CT secret-bearing
+surfaces.
+
+**1. The disagreement it removes**
+
+For a 64-byte compact signature, "valid" previously depended on which GPU route
+handled the row. CUDA's batch kernel and the OpenCL parsers rejected `r >= n`
+or `s >= n` (strict compact parse); CUDA's collect kernel, Metal's
+batch/collect, and the device-side single-verify path reduced the raw limbs
+mod `n` before comparing, so the non-canonical `(r, s + n)` encoding (congruent
+mod `n`, and representable in 32 bytes whenever `s < 2^256 - n`) verified
+exactly like the canonical one. The same 64 bytes changed meaning by entrypoint,
+which also broke the documented guarantee in `src/gpu/src/gpu_backend_cuda.cu`
+that the collect verdict is bit-identical to `verify_batch`.
+
+- **Security claim: one uniform contract.** Every device-side `ecdsa_verify()`
+  (the single choke point shared by the single/batch/collect entrypoints and the
+  sign-and-verify countermeasure) now rejects `r >= n || s >= n` up front.
+  Boundary inputs verify identically against the CPU strict oracle
+  (`ufsecp_ecdsa_verify`, `parse_compact_strict` + low-S), so a compact
+  signature either verifies everywhere or nowhere across CPU, CUDA, OpenCL and
+  Metal.
+- **No CT boundary change:** `r` and `s` are PUBLIC bytes of the signature. The
+  guard is a fixed-limb `>=` comparison with no secret-dependent branch or
+  memory access, and it runs before any secret-touching verify math.
+- **No secret lifecycle change:** no new resident secret buffer, no added or
+  removed `secure_erase` site — see `docs/SECRET_LIFECYCLE.md` for the pairing.
+- **Tests:** `audit/test_regression_gpu_ecdsa_compact_range.cpp` — `[A]` a
+  CPU-only source gate pins the guard in the CUDA `.cuh`, Metal shader and
+  OpenCL kernel (renders the divergence un-buildable); `[B]` an on-device
+  boundary differential over `{0, n-1, n, 2^256-1, s+n}` rows through both
+  batch and collect, checked row-by-row against the CPU oracle. Invalid rows
+  stay at the seeded marker (fail-closed). Rows are synced into
+  `docs/CT_VERIFICATION.md` / `docs/TEST_MATRIX.md` by `ci/sync_all_docs.py`.
+
 ### 2026-09-07 - Fixed-base disk cache OFF by default, FE52 kernels always inlined, PT_TLS alignment (build-surface changes; no CT boundary moves)
 
 Three changes in this wave touch the root `CMakeLists.txt` and the FE52 field

--- a/docs/SECURITY_CLAIMS.md
+++ b/docs/SECURITY_CLAIMS.md
@@ -33,12 +33,14 @@ that the collect verdict is bit-identical to `verify_batch`.
   memory access, and it runs before any secret-touching verify math.
 - **No secret lifecycle change:** no new resident secret buffer, no added or
   removed `secure_erase` site — see `docs/SECRET_LIFECYCLE.md` for the pairing.
-- **Tests:** `audit/test_regression_gpu_ecdsa_compact_range.cpp` — `[A]` a
-  CPU-only source gate pins the guard in the CUDA `.cuh`, Metal shader and
-  OpenCL kernel (renders the divergence un-buildable); `[B]` an on-device
-  boundary differential over `{0, n-1, n, 2^256-1, s+n}` rows through both
-  batch and collect, checked row-by-row against the CPU oracle. Invalid rows
-  stay at the seeded marker (fail-closed). Rows are synced into
+- **Tests:** `audit/test_gpu_ecdsa_compact_range.cpp` — `[A]` a
+  CPU-only source gate pins the guard inside each backend's `ecdsa_verify()`
+  body (before `scalar_inverse`), so a guard stranded in a helper no verify
+  path calls cannot satisfy it; `[B]` an on-device boundary differential over
+  a small-`(r, s)` recovered base and its congruent malleations
+  `(r, s+n)/(r+n, s)/(r+n, s+n)` plus the `{0, n-1, n, 2^256-1}` extremes,
+  through both batch and collect, checked row-by-row against the CPU oracle.
+  Invalid rows stay at the seeded marker (fail-closed). Rows are synced into
   `docs/CT_VERIFICATION.md` / `docs/TEST_MATRIX.md` by `ci/sync_all_docs.py`.
 
 ### 2026-09-07 - Fixed-base disk cache OFF by default, FE52 kernels always inlined, PT_TLS alignment (build-surface changes; no CT boundary moves)

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -57,7 +57,7 @@ lags behind the generated validation surfaces, prefer the generated counts.
 | `test_frost_kat.cpp` | -- | FROST t-of-n threshold signing known-answer tests |
 | `test_wycheproof_ecdsa.cpp` | -- | Wycheproof ECDSA: Google Project Wycheproof test vectors |
 | `test_wycheproof_ecdh.cpp` | -- | Wycheproof ECDH: Google Project Wycheproof test vectors |
-| `unified_audit_runner.cpp` | 475 modules (199 non-exploit + 276 exploit PoCs) | Unified audit: all current modules in single binary (includes GPU null-guard paths) |
+| `unified_audit_runner.cpp` | 476 modules (200 non-exploit + 276 exploit PoCs) | Unified audit: all current modules in single binary (includes GPU null-guard paths) |
 
 ### CPU Unit Tests (`src/cpu/tests/`)
 
@@ -106,14 +106,14 @@ lags behind the generated validation surfaces, prefer the generated counts.
 |------|---------|-------|
 | `opencl/tests/test_opencl.cpp` | OpenCL | Kernel correctness |
 | `opencl/tests/opencl_extended_test.cpp` | OpenCL | Extended operations |
-| `opencl/src/opencl_audit_runner.cpp` | OpenCL | Unified GPU audit ( 475 modules, 8 sections) |
+| `opencl/src/opencl_audit_runner.cpp` | OpenCL | Unified GPU audit ( 476 modules, 8 sections) |
 | `metal/tests/test_metal_host.cpp` | Metal | Metal shader correctness |
-| `metal/src/metal_audit_runner.mm` | Metal | `secp256k1_metal_audit`: unified GPU audit ( 475 modules, 8 sections) |
+| `metal/src/metal_audit_runner.mm` | Metal | `secp256k1_metal_audit`: unified GPU audit ( 476 modules, 8 sections) |
 | `src/cuda/src/test_ct_smoke.cu` | CUDA | CT smoke tests incl. ZK knowledge + DLEQ prove/verify (9 tests) |
 | `src/cuda/src/gpu_ct_leakage_probe.cu` | CUDA | Fixed-vs-random device-cycle Welch t-test on CT generator and signing kernels with JSON evidence output |
 | `src/cuda/src/test_suite.cu` | CUDA | `cuda_selftest`: kernel correctness, field + scalar + point ops |
 | `src/cuda/src/test_windows_macro_compat.cu` | CUDA/MSVC | `cuda_windows_macro_compat`: compile regression for Windows SDK `small` macro collisions in the public CUDA header |
-| `src/cuda/src/gpu_audit_runner.cu` | CUDA | `gpu_audit`: unified GPU audit ( 475 modules, 8 sections) |
+| `src/cuda/src/gpu_audit_runner.cu` | CUDA | `gpu_audit`: unified GPU audit ( 476 modules, 8 sections) |
 
 | `metal/app/metal_test.mm` | Metal | `secp256k1_metal_test`: shader correctness, compute pipeline |
 | `metal/app/bench_metal.mm` | Metal | `secp256k1_metal_bench_full`: comprehensive Metal benchmark |

--- a/docs/WHY_ULTRAFASTSECP256K1.md
+++ b/docs/WHY_ULTRAFASTSECP256K1.md
@@ -76,10 +76,10 @@ These top-level differentiators are claim-keyed in the ledger: exploit-audit sur
 | ABI gate | FFI round-trip stability, C ABI regression detection | Full suite |
 | Performance regression | Micro-benchmark gate available for release/manual deep assurance | Manual / release |
 | **Deep differential** | Random round-trip differential tests against reference implementations | **~1,300,000+ per deep run** |
-| **Total (audit runner)** | **unified_audit_runner** across 199 non-exploit modules + 276 exploit-PoC modules (475 total) | **~1,000,000+** |
+| **Total (audit runner)** | **unified_audit_runner** across 200 non-exploit modules + 276 exploit-PoC modules (476 total) | **~1,000,000+** |
 | **Total (exploit PoC tests)** | **276 exploit-PoC modules** (264 source files — 9 modules share a file or use inline shim stubs) across 20+ coverage categories | **276 modules, 0 failures** |
 
-All 199 non-exploit audit modules across all tested platforms return **AUDIT-READY**. Zero failures in the current CI run (not a lifetime claim — see `docs/AUDIT_COVERAGE.md` for current status).
+All 200 non-exploit audit modules across all tested platforms return **AUDIT-READY**. Zero failures in the current CI run (not a lifetime claim — see `docs/AUDIT_COVERAGE.md` for current status).
 All 276 exploit-PoC modules pass. Zero failures in the current CI run across all 20+ coverage categories.
 
 ### Self-Audit Documents

--- a/docs/canonical_data.json
+++ b/docs/canonical_data.json
@@ -1,9 +1,9 @@
 {
   "version": "4.5.0",
-  "last_updated": "2026-09-09",
+  "last_updated": "2026-09-10",
   "exploit_poc_count": 276,
-  "non_exploit_modules": 199,
-  "total_modules": 475,
+  "non_exploit_modules": 200,
+  "total_modules": 476,
   "ci_workflow_count": 58,
   "ct_pipeline_count": 5,
   "bitcoin_core_tests_pass": 749,

--- a/src/cuda/include/ecdsa.cuh
+++ b/src/cuda/include/ecdsa.cuh
@@ -349,6 +349,14 @@ __device__ inline bool ecdsa_verify(
     // Check r, s are non-zero
     if (scalar_is_zero(&sig->r) || scalar_is_zero(&sig->s)) return false;
 
+    // Reject out-of-range compact scalars (r >= n or s >= n). The batch kernel
+    // already rejects these in ecdsa_sig_parse_compact_strict; the collect path
+    // consumes host-preconverted limbs with no parse (bytes_to_ecdsa_sig), so
+    // this single guard keeps EVERY ecdsa_verify route identical. Previously the
+    // collect path reduced s+n (s >= n) mod n, silently accepting a malleated
+    // compact signature that batch/OpenCL/CPU all reject as non-canonical.
+    if (scalar_ge(&sig->r, ORDER) || scalar_ge(&sig->s, ORDER)) return false;
+
     // z = message hash as scalar
     Scalar z;
     scalar_from_bytes(msg_hash, &z);

--- a/src/metal/shaders/secp256k1_extended.h
+++ b/src/metal/shaders/secp256k1_extended.h
@@ -1040,9 +1040,27 @@ inline bool ecdsa_sign(thread const uchar msg_hash[32], thread const Scalar256 &
 }
 #endif // !SECP256K1_METAL_SCAN_ONLY
 
+// Compare a parsed 8x32-bit scalar (limbs[7] = most-significant word, matching
+// SECP256K1_N[8] layout) against the group order; true when s >= n (out of
+// range). Parity with the strict compact-parse contract of CUDA/OpenCL: an
+// r/s >= n compact encoding is non-canonical and must NOT verify, otherwise the
+// collect/batch paths would accept s+n malleations that CPU/batch reject.
+inline bool scalar256_ge_n(thread const Scalar256 &s) {
+    for (int i = 7; i >= 0; --i) {
+        if (s.limbs[i] > SECP256K1_N[i]) return true;
+        if (s.limbs[i] < SECP256K1_N[i]) return false;
+    }
+    return true;   // s == n -> out of range
+}
+
 inline bool ecdsa_verify(thread const uchar msg_hash[32], thread const JacobianPoint &pubkey,
                           thread const ECDSASignature &sig) {
     if (scalar256_is_zero(sig.r) || scalar256_is_zero(sig.s)) return false;
+
+    // Reject out-of-range compact scalars (r >= n or s >= n) so every Metal
+    // verify route matches the strict compact-parse contract of CUDA/OpenCL
+    // (batch_compressed + lbtc collect previously reduced s+n mod n here).
+    if (scalar256_ge_n(sig.r) || scalar256_ge_n(sig.s)) return false;
 
     Scalar256 z = scalar_from_bytes(msg_hash);
     Scalar256 s_inv = scalar_inverse(sig.s);

--- a/src/metal/shaders/secp256k1_extended.h
+++ b/src/metal/shaders/secp256k1_extended.h
@@ -1040,19 +1040,6 @@ inline bool ecdsa_sign(thread const uchar msg_hash[32], thread const Scalar256 &
 }
 #endif // !SECP256K1_METAL_SCAN_ONLY
 
-// Compare a parsed 8x32-bit scalar (limbs[7] = most-significant word, matching
-// SECP256K1_N[8] layout) against the group order; true when s >= n (out of
-// range). Parity with the strict compact-parse contract of CUDA/OpenCL: an
-// r/s >= n compact encoding is non-canonical and must NOT verify, otherwise the
-// collect/batch paths would accept s+n malleations that CPU/batch reject.
-inline bool scalar256_ge_n(thread const Scalar256 &s) {
-    for (int i = 7; i >= 0; --i) {
-        if (s.limbs[i] > SECP256K1_N[i]) return true;
-        if (s.limbs[i] < SECP256K1_N[i]) return false;
-    }
-    return true;   // s == n -> out of range
-}
-
 inline bool ecdsa_verify(thread const uchar msg_hash[32], thread const JacobianPoint &pubkey,
                           thread const ECDSASignature &sig) {
     if (scalar256_is_zero(sig.r) || scalar256_is_zero(sig.s)) return false;
@@ -1060,7 +1047,9 @@ inline bool ecdsa_verify(thread const uchar msg_hash[32], thread const JacobianP
     // Reject out-of-range compact scalars (r >= n or s >= n) so every Metal
     // verify route matches the strict compact-parse contract of CUDA/OpenCL
     // (batch_compressed + lbtc collect previously reduced s+n mod n here).
-    if (scalar256_ge_n(sig.r) || scalar256_ge_n(sig.s)) return false;
+    Scalar256 order_n;
+    for (int i = 0; i < 8; i++) order_n.limbs[i] = SECP256K1_N[i];
+    if (scalar256_ge(sig.r, order_n) || scalar256_ge(sig.s, order_n)) return false;
 
     Scalar256 z = scalar_from_bytes(msg_hash);
     Scalar256 s_inv = scalar_inverse(sig.s);

--- a/src/opencl/kernels/secp256k1_extended.cl
+++ b/src/opencl/kernels/secp256k1_extended.cl
@@ -1355,6 +1355,11 @@ inline int ecdsa_sign_impl(const uchar msg_hash[32], const Scalar* priv, ECDSASi
 inline int ecdsa_verify_impl(const uchar msg_hash[32], const JacobianPoint* pubkey, const ECDSASignature* sig) {
     if (scalar_is_zero(&sig->r) || scalar_is_zero(&sig->s)) return 0;
 
+    // Reject out-of-range scalars (r >= n or s >= n) so every OpenCL verify
+    // route matches the strict compact/opaque parse contract (defense in depth:
+    // ecdsa_verify_impl itself previously reduced these mod n).
+    if (lbtc_scalar_ge_order(&sig->r) || lbtc_scalar_ge_order(&sig->s)) return 0;
+
     Scalar z;
     scalar_from_bytes_impl(msg_hash, &z);
 


### PR DESCRIPTION
## Summary

Consensus-relevant divergence: for a **compact ECDSA signature whose `r` or `s` is out of the scalar range `[1, n-1]`** (`r >= n` or `s >= n`), the verification verdict differed by backend and by entrypoint:

| Path | Behavior |
|---|---|
| CUDA `ecdsa_verify_batch_kernel` | strict (`ecdsa_sig_parse_compact_strict`) |
| CUDA `ecdsa_verify_collect_kernel` | **permissive** (host `bytes_to_ecdsa_sig` + device `ecdsa_verify` reduced limbs mod n) |
| Metal `ecdsa_verify_batch_compressed` | **permissive** (mod-n reduction) |
| Metal `lbtc_ecdsa_verify_collect` | **permissive** (mod-n reduction) |
| OpenCL `ecdsa_verify_*` | strict (`lbtc_parse_compact_signature`) |
| CPU `ufsecp_ecdsa_verify` | strict (`parse_compact_strict` + low-S) |

Because `s` and `s+n` are congruent mod n, the permissive paths verified the non-canonical `(r, s+n)` encoding identically to `(r, s)` while the strict paths rejected it — the same 64 bytes changed meaning depending on which GPGPU API shipped the row, violating the documented invariant in `gpu_backend_cuda.cu` ("EC verdict is **bit-identical** to verify_batch") and the analogous Metal shader invariant.

## Fix

Each backend's device-side `ecdsa_verify()` is the single choke point shared by single/batch/collect and the sign-and-verify countermeasure. It now rejects `r >= n || s >= n` up front:

- `src/cuda/include/ecdsa.cuh` — `scalar_ge(&sig->r, ORDER) || scalar_ge(&sig->s, ORDER)`
- `src/metal/shaders/secp256k1_extended.h` — new `scalar256_ge_n()` limb compare against `SECP256K1_N`
- `src/opencl/kernels/secp256k1_extended.cl` — `lbtc_scalar_ge_order()` (defense in depth; its parsers were already strict)

One uniform strict compact contract across CPU, CUDA, OpenCL and Metal. CUDA batch keeps its strict parse; signing is unaffected (canonical output is always `< n`).

## Regression coverage — `audit/test_regression_gpu_ecdsa_compact_range.cpp`

- **[A] CPU-only source gate** (always runs, every runner, no GPU): scans the in-tree kernel sources and asserts the strict range guard is present in each backend's `ecdsa_verify()`. **FAILS against the pre-fix sources** — mutation-tested locally (stripping one guard → `fail=1`, exit 1; restored → `12/12` pass).
- **[B] On-device boundary-scalar differential** (advisory; self-skips without a GPU): `r/s` on the `{0, n-1, n, 2^256-1, s+n-congruent}` boundary through BOTH batch and collect, asserting per-row uniformity with the CPU strict oracle and the fail-closed seeded-marker contract.
- Registered in `unified_audit_runner` (advisory=false, since the source gate must pass everywhere) + standalone CTest target (`gpu;ecdsa;range;differential;regression`).

## Local verification performed

- Module compiles `-Wall -Wextra -Werror` clean (standalone + `-DUNIFIED_AUDIT_RUNNER` variants).
- Stubbed standalone run: source gate `12/12` pass against the edited kernel files; GPU differential self-skips (no GPU here).
- Mutation test: removing the CUDA `s` guard → gate fails (exit 1) → restored.
- CMake configure OK (CPU-only and Metal-enabled); `test_gpu_ecdsa_compact_range` target + ctest entry wired.
- Docs: `python3 ci/sync_all_docs.py` + `--check` green (module counts 475→476, non-exploit 198→199 … 199→200).

## Heads-up for the evidence bundle

`docs/EXTERNAL_AUDIT_BUNDLE.{json,sha256}` evidence hashes are now stale because the module-count sync touched `docs/TEST_MATRIX.md`, `docs/CT_VERIFICATION.md` and `docs/CROSS_PLATFORM_TEST_MATRIX.md`. Needs the same `external_audit_bundle.py` regeneration you ran in `d7ea22c` for #408 (local `audit_gate.py` requires the `.project_graph.db` build, so I left it for that flow).

Signed-off-by: kawacukennedy <kawacukennedy@users.noreply.github.com>
